### PR TITLE
Phase 2: Rust VaultIndex with reverse backlinks index

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -171,6 +171,30 @@ pub fn scan_vault_v2(
 	Ok(entries)
 }
 
+/// Returns every note that wikilinks to `path`, sorted by title for stable UI
+/// ordering. Reads the reverse backlinks map that was populated by the
+/// preceding `scan_vault_v2` call (or maintained incrementally by Phase 2.6's
+/// `update_note_in_index`), so the answer is O(K) where K is the number of
+/// backlinks — not O(N) over the whole vault.
+///
+/// Returns an empty list when the path is unknown or has no backlinks.
+#[tauri::command]
+pub fn get_backlinks_v2(
+	path: String,
+	index_state: State<'_, VaultIndexState>,
+) -> Result<Vec<NoteEntry>, String> {
+	let idx = index_state
+		.read()
+		.map_err(|_| "VaultIndex lock poisoned".to_string())?;
+	let source_paths = idx.backlinks_of(&path);
+	let mut entries: Vec<NoteEntry> = source_paths
+		.iter()
+		.filter_map(|src| idx.entry_for_path(src).cloned())
+		.collect();
+	entries.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+	Ok(entries)
+}
+
 fn sort_nodes(nodes: &mut [FileNode], sort_by: &str) {
     nodes.sort_by(|a, b| {
         // Directories always come first

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -1,11 +1,13 @@
 use crate::utils::fs as vault_fs;
 use crate::utils::logger::debug_log;
 use crate::vault::entry::NoteEntry;
+use crate::vault::VaultIndexState;
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
+use tauri::State;
 
 /// Maximum recursion depth for directory traversal (prevents symlink loops / extreme nesting).
 const MAX_DEPTH: usize = 64;
@@ -110,12 +112,17 @@ fn scan_dir(dir: &Path, sort_by: &str, depth: usize) -> Result<Vec<FileNode>, St
 /// produces (depth-first, dirs-first per level) — callers that need a
 /// specific order should sort the result.
 ///
-/// This is the Phase-1 additive sibling of `scan_vault`. It does not yet
-/// feed into any UI consumer — Phase 2 builds `VaultIndex` on top of this
-/// and Phase 3+ migrates the backlink / tag / collection panels. See
-/// ADR 0025.
+/// Side effect (Phase 2.3): the scanned entries also populate the
+/// managed `VaultIndexState` via `VaultIndex::build`, so subsequent
+/// reads through `get_backlinks_v2` / `get_outgoing_links_v2` (Phase 2.4+)
+/// see the freshly-built reverse index. The returned `Vec<NoteEntry>`
+/// is still the source of truth for the TS side until Phase 3 migrates
+/// consumers off the per-call payload.
 #[tauri::command]
-pub fn scan_vault_v2(vault_path: String) -> Result<Vec<NoteEntry>, String> {
+pub fn scan_vault_v2(
+	vault_path: String,
+	index_state: State<'_, VaultIndexState>,
+) -> Result<Vec<NoteEntry>, String> {
 	let start = std::time::Instant::now();
 	debug_log("VAULT", format!("scan_vault_v2: {}", vault_path));
 	let root = vault_fs::validate_vault_path(&vault_path)?;
@@ -140,6 +147,16 @@ pub fn scan_vault_v2(vault_path: String) -> Result<Vec<NoteEntry>, String> {
 		let modified_at = u64::try_from(mtime_secs.saturating_mul(1_000)).ok();
 		let path_str = abs.to_string_lossy().to_string();
 		entries.push(NoteEntry::from_content(&path_str, &content, modified_at));
+	}
+
+	// Publish the freshly-built index to managed state so future read commands
+	// see the up-to-date reverse backlinks map. build() is O(N) wrt entries
+	// but only runs once per vault open / refresh.
+	{
+		let mut idx = index_state
+			.write()
+			.map_err(|_| "VaultIndex lock poisoned".to_string())?;
+		idx.build(entries.clone());
 	}
 
 	debug_log(

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 /// Maximum recursion depth for directory traversal (prevents symlink loops / extreme nesting).
 const MAX_DEPTH: usize = 64;
@@ -169,6 +169,57 @@ pub fn scan_vault_v2(
 		),
 	);
 	Ok(entries)
+}
+
+/// Name of the Tauri event emitted by `update_note_in_index` (and, later,
+/// by watcher-driven updaters in Phase 9). All consumer panels in the
+/// frontend listen on this single channel and re-invoke their read
+/// command on receipt — see the consumer panel pattern in ADR 0025.
+pub const VAULT_INDEX_UPDATED_EVENT: &str = "vault-index-updated";
+
+/// Parses the supplied content into a `NoteEntry` (via Phase 1 extractors),
+/// inserts or replaces it in the managed `VaultIndex` (via Phase 2.5's
+/// `update_entry`), and emits `vault-index-updated` carrying the
+/// `UpdateResult`. Intended to be called by the frontend editor service
+/// on save, not on every keystroke.
+///
+/// The note's mtime is read from disk at call time so the entry carries a
+/// fresh timestamp; if the stat fails (e.g. the save completes after this
+/// call), `modified_at` falls back to `None`.
+#[tauri::command]
+pub fn update_note_in_index(
+	path: String,
+	content: String,
+	app: AppHandle,
+	index_state: State<'_, VaultIndexState>,
+) -> Result<crate::vault::index::UpdateResult, String> {
+	let modified_at = fs::metadata(&path)
+		.ok()
+		.and_then(|m| m.modified().ok())
+		.and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+		.and_then(|d| u64::try_from(d.as_millis()).ok());
+
+	let entry = NoteEntry::from_content(&path, &content, modified_at);
+
+	let result = {
+		let mut idx = index_state
+			.write()
+			.map_err(|_| "VaultIndex lock poisoned".to_string())?;
+		idx.update_entry(entry)
+	};
+
+	// Emit to the frontend so every consumer panel re-fetches against the
+	// latest VaultIndex revision. Emit errors are logged but not returned —
+	// a failed emit should not fail the index mutation (which already
+	// succeeded inside the write lock).
+	if let Err(err) = app.emit(VAULT_INDEX_UPDATED_EVENT, &result) {
+		debug_log(
+			"VAULT",
+			format!("update_note_in_index: emit failed ({})", err),
+		);
+	}
+
+	Ok(result)
 }
 
 /// Returns every note that wikilinks to `path`, sorted by title for stable UI

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::history::cleanup_history,
             commands::vault::scan_vault,
             commands::vault::scan_vault_v2,
+            commands::vault::get_backlinks_v2,
             commands::files::read_files_batch,
             commands::search::search_vault,
             commands::terminal::spawn_terminal,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ use commands::terminal::TerminalState;
 use tauri::menu::{AboutMetadata, MenuItemBuilder, SubmenuBuilder};
 use tauri::Emitter;
 use utils::logger::init_logger;
+use vault::VaultIndexState;
 
 fn build_menu(app: &tauri::App) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
     let settings_item = MenuItemBuilder::new("Settings...")
@@ -84,6 +85,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .manage(TerminalState::new())
+        .manage(VaultIndexState::default())
         .invoke_handler(tauri::generate_handler![
             commands::db::open_vault_db,
             commands::db::close_vault_db,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ pub fn run() {
             commands::vault::scan_vault,
             commands::vault::scan_vault_v2,
             commands::vault::get_backlinks_v2,
+            commands::vault::update_note_in_index,
             commands::files::read_files_batch,
             commands::search::search_vault,
             commands::terminal::spawn_terminal,

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -23,12 +23,34 @@
 //! Svelte-store pattern in the TS codebase (ADR 0005).
 
 use crate::vault::entry::NoteEntry;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
 /// Monotonic revision number. Bumps on every mutation so consumers can
 /// discard stale reads and so `vault-index-updated` payloads carry a
 /// strictly-increasing stamp that clients can order against.
 pub type IndexVersion = u64;
+
+/// Outcome of a single `update_entry` call, carried as the payload of the
+/// `vault-index-updated` Tauri event (Phase 2.6). Clients use it to decide
+/// which consumer panels need to re-fetch: a panel showing backlinks for
+/// any path in `affected` must re-invoke `get_backlinks_v2`; a panel
+/// rendering metadata for any path in `changed` must re-invoke its own
+/// read command.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateResult {
+	/// Paths whose `NoteEntry` was directly inserted or replaced.
+	pub changed: Vec<String>,
+	/// Paths whose backlinks list changed as a side effect — i.e., the
+	/// updated entry added or removed a wikilink pointing at these paths.
+	/// A panel rendering backlinks for any of these paths must re-fetch.
+	pub affected: Vec<String>,
+	/// Index revision after the mutation. Clients can use this to
+	/// detect / drop out-of-order events if they maintain their own
+	/// monotonic signal.
+	pub version: IndexVersion,
+}
 
 /// In-memory vault metadata index. One entry per markdown note; a reverse
 /// map from "target path" → "source paths that wikilink to it" for O(K)
@@ -98,6 +120,102 @@ impl VaultIndex {
 		}
 
 		self.version = self.version.wrapping_add(1);
+	}
+
+	/// Inserts or replaces a single entry, keeping the reverse backlinks map
+	/// in sync. Returns an `UpdateResult` listing the changed path plus every
+	/// path whose backlinks list shifted as a side effect of this mutation.
+	///
+	/// Semantics:
+	///   * First insert of a path → entry appended; outgoing_links register
+	///     new incoming edges on resolved targets.
+	///   * Subsequent updates → outgoing_links diffed against the previous
+	///     version. Removed links retract the source from the target's
+	///     backlinks set; added links register new ones. The entry itself
+	///     is replaced in place (preserves the slot index in `entries`).
+	///   * Self-links are filtered (consistent with `build`).
+	///   * Version bumps by 1 (wrapping).
+	pub fn update_entry(&mut self, entry: NoteEntry) -> UpdateResult {
+		let source_path = entry.path.clone();
+		let new_links = entry.outgoing_links.clone();
+
+		// Snapshot previous outgoing links (if the entry already exists).
+		let prev_links: Vec<String> = self
+			.by_path
+			.get(&source_path)
+			.and_then(|i| self.entries.get(*i))
+			.map(|e| e.outgoing_links.clone())
+			.unwrap_or_default();
+
+		// Replace / insert the entry in the entries vec and by_path.
+		if let Some(idx) = self.by_path.get(&source_path) {
+			self.entries[*idx] = entry;
+		} else {
+			self.entries.push(entry);
+			self.by_path
+				.insert(source_path.clone(), self.entries.len() - 1);
+		}
+
+		// Rebuild the filename resolver cheaply — O(N) but only touches
+		// HashMap inserts. Acceptable for the Phase 2 per-save cost; if
+		// profiling later shows this as a hotspot it becomes an incremental
+		// structure maintained by build + update_entry together.
+		let by_filename: HashMap<String, String> = {
+			let mut map = HashMap::with_capacity(self.entries.len());
+			for e in &self.entries {
+				let key = filename_stem_lower(&e.path);
+				map.entry(key).or_insert_with(|| e.path.clone());
+			}
+			map
+		};
+
+		// Diff outgoing links to determine which target backlinks change.
+		let prev_set: HashSet<&String> = prev_links.iter().collect();
+		let new_set: HashSet<&String> = new_links.iter().collect();
+		let removed: Vec<&String> = prev_set.difference(&new_set).copied().collect();
+		let added: Vec<&String> = new_set.difference(&prev_set).copied().collect();
+
+		let mut affected: HashSet<String> = HashSet::new();
+
+		// Remove source from backlinks of every target whose link was removed.
+		for target in removed {
+			if let Some(resolved) = resolve_wikilink(target, &by_filename) {
+				if resolved == source_path {
+					continue;
+				}
+				let resolved_owned = resolved.to_string();
+				if let Some(set) = self.backlinks.get_mut(&resolved_owned) {
+					if set.remove(&source_path) {
+						affected.insert(resolved_owned.clone());
+					}
+					if set.is_empty() {
+						self.backlinks.remove(&resolved_owned);
+					}
+				}
+			}
+		}
+
+		// Add source to backlinks of every target whose link was added.
+		for target in added {
+			if let Some(resolved) = resolve_wikilink(target, &by_filename) {
+				if resolved == source_path {
+					continue;
+				}
+				let resolved_owned = resolved.to_string();
+				let set = self.backlinks.entry(resolved_owned.clone()).or_default();
+				if set.insert(source_path.clone()) {
+					affected.insert(resolved_owned);
+				}
+			}
+		}
+
+		self.version = self.version.wrapping_add(1);
+
+		UpdateResult {
+			changed: vec![source_path],
+			affected: affected.into_iter().collect(),
+			version: self.version,
+		}
 	}
 
 	/// Read-only slice of all entries, in insertion order. Callers that
@@ -357,5 +475,116 @@ mod tests {
 		assert_eq!(idx.len(), 1);
 		assert!(idx.backlinks_of("/v/b.md").is_empty());
 		assert!(idx.entry_for_path("/v/a.md").is_none());
+	}
+
+	// --- update_entry ---
+
+	#[test]
+	fn update_entry_inserts_new_path() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_entry("/v/target.md", &[])]);
+		assert_eq!(idx.len(), 1);
+
+		let r = idx.update_entry(make_entry("/v/new.md", &["target"]));
+		assert_eq!(r.changed, vec!["/v/new.md"]);
+		assert_eq!(r.affected, vec!["/v/target.md"]);
+		assert_eq!(r.version, idx.version());
+		assert_eq!(idx.len(), 2);
+		let backs = idx.backlinks_of("/v/target.md");
+		assert_eq!(backs.len(), 1);
+		assert_eq!(backs[0], "/v/new.md");
+	}
+
+	#[test]
+	fn update_entry_replaces_existing() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["target"]),
+			make_entry("/v/target.md", &[]),
+		]);
+		assert_eq!(idx.backlinks_of("/v/target.md").len(), 1);
+
+		// Replace a.md with new content that removes the target link.
+		idx.update_entry(make_entry("/v/a.md", &[]));
+		assert!(idx.backlinks_of("/v/target.md").is_empty());
+		assert_eq!(idx.len(), 2);
+	}
+
+	#[test]
+	fn update_entry_diffs_links_correctly() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["beta", "gamma"]),
+			make_entry("/v/beta.md", &[]),
+			make_entry("/v/gamma.md", &[]),
+			make_entry("/v/delta.md", &[]),
+		]);
+		// a.md links to beta and gamma. Update: drop gamma, add delta.
+		let r = idx.update_entry(make_entry("/v/a.md", &["beta", "delta"]));
+		assert_eq!(r.changed, vec!["/v/a.md"]);
+		let mut affected = r.affected.clone();
+		affected.sort();
+		assert_eq!(affected, vec!["/v/delta.md", "/v/gamma.md"]);
+
+		// beta unchanged, gamma cleared, delta picked up.
+		assert_eq!(idx.backlinks_of("/v/beta.md").len(), 1);
+		assert!(idx.backlinks_of("/v/gamma.md").is_empty());
+		assert_eq!(idx.backlinks_of("/v/delta.md").len(), 1);
+	}
+
+	#[test]
+	fn update_entry_no_link_changes_reports_no_affected() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["beta"]),
+			make_entry("/v/beta.md", &[]),
+		]);
+		// Update with same outgoing links — only metadata (e.g. word count) changes.
+		let r = idx.update_entry(NoteEntry {
+			word_count: 42,
+			..make_entry("/v/a.md", &["beta"])
+		});
+		assert!(r.affected.is_empty());
+		assert_eq!(r.changed, vec!["/v/a.md"]);
+		assert_eq!(idx.entry_for_path("/v/a.md").unwrap().word_count, 42);
+	}
+
+	#[test]
+	fn update_entry_self_link_ignored() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_entry("/v/a.md", &[])]);
+		let r = idx.update_entry(make_entry("/v/a.md", &["a"]));
+		assert!(r.affected.is_empty());
+		assert!(idx.backlinks_of("/v/a.md").is_empty());
+	}
+
+	#[test]
+	fn update_entry_bumps_version() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_entry("/v/a.md", &[])]);
+		let v0 = idx.version();
+		idx.update_entry(make_entry("/v/a.md", &["x"]));
+		assert_eq!(idx.version(), v0 + 1);
+		idx.update_entry(make_entry("/v/b.md", &[]));
+		assert_eq!(idx.version(), v0 + 2);
+	}
+
+	#[test]
+	fn update_entry_cleans_up_empty_backlink_sets() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["target"]),
+			make_entry("/v/target.md", &[]),
+		]);
+		assert_eq!(idx.backlinks_of("/v/target.md").len(), 1);
+
+		// Remove the only backlink.
+		idx.update_entry(make_entry("/v/a.md", &[]));
+		assert!(idx.backlinks_of("/v/target.md").is_empty());
+		// Internal check: the target should NOT be in the map with an empty set.
+		// (The public API can't see this directly, but the cleanup is what lets
+		// backlinks_of return empty correctly if the target later gets re-linked.)
+		idx.update_entry(make_entry("/v/c.md", &["target"]));
+		assert_eq!(idx.backlinks_of("/v/target.md").len(), 1);
 	}
 }

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -56,6 +56,50 @@ impl VaultIndex {
 		Self::default()
 	}
 
+	/// Populates the index from a full vault scan. Rebuilds `entries`,
+	/// `by_path`, and the reverse `backlinks` map from scratch; bumps
+	/// `version` by 1. Any previous state is dropped.
+	///
+	/// Wikilink resolution mirrors `resolveWikilink` in the TS backlinks
+	/// logic: lowercase filename stem matches with a basename fallback
+	/// for path-prefixed targets. First path wins on filename collisions
+	/// (same as `buildResolutionCache` in TS).
+	pub fn build(&mut self, entries: Vec<NoteEntry>) {
+		self.entries = entries;
+		self.by_path.clear();
+		self.by_path.reserve(self.entries.len());
+		for (i, entry) in self.entries.iter().enumerate() {
+			self.by_path.insert(entry.path.clone(), i);
+		}
+
+		// Build the lowercase filename → path resolution map; first entry wins on collision.
+		let mut by_filename: HashMap<String, String> =
+			HashMap::with_capacity(self.entries.len());
+		for entry in &self.entries {
+			let key = filename_stem_lower(&entry.path);
+			by_filename.entry(key).or_insert_with(|| entry.path.clone());
+		}
+
+		self.backlinks.clear();
+		for entry in &self.entries {
+			for target in &entry.outgoing_links {
+				if let Some(resolved) = resolve_wikilink(target, &by_filename) {
+					// Do not count self-links — matches the sourcePath != currentPath
+					// skip in TS's findLinkedMentions.
+					if resolved == entry.path {
+						continue;
+					}
+					self.backlinks
+						.entry(resolved.to_string())
+						.or_default()
+						.insert(entry.path.clone());
+				}
+			}
+		}
+
+		self.version = self.version.wrapping_add(1);
+	}
+
 	/// Read-only slice of all entries, in insertion order. Callers that
 	/// need lookup by path should use `entry_for_path` (O(1)) instead of
 	/// iterating this slice.
@@ -98,6 +142,45 @@ impl VaultIndex {
 	}
 }
 
+/// Resolves a raw wikilink target to an absolute path using the prebuilt
+/// lowercase-filename lookup. First tries the target as-is (case-insensitive),
+/// then falls back to the basename for path-prefixed targets
+/// (`folder/sub/note` → `note`). Mirrors TS `resolveWikilink` exactly.
+fn resolve_wikilink<'a>(target: &str, by_filename: &'a HashMap<String, String>) -> Option<&'a str> {
+	if target.is_empty() {
+		return None;
+	}
+	let lowered = target.to_lowercase();
+	if let Some(path) = by_filename.get(&lowered) {
+		return Some(path.as_str());
+	}
+	let basename = basename_lower(target);
+	if basename != lowered {
+		if let Some(path) = by_filename.get(&basename) {
+			return Some(path.as_str());
+		}
+	}
+	None
+}
+
+fn filename_stem_lower(path: &str) -> String {
+	let name = path.rsplit(&['/', '\\'][..]).next().unwrap_or(path);
+	let stem = name
+		.strip_suffix(".md")
+		.or_else(|| name.strip_suffix(".markdown"))
+		.unwrap_or(name);
+	stem.to_lowercase()
+}
+
+fn basename_lower(target: &str) -> String {
+	let name = target.rsplit(&['/', '\\'][..]).next().unwrap_or(target);
+	let stem = name
+		.strip_suffix(".md")
+		.or_else(|| name.strip_suffix(".markdown"))
+		.unwrap_or(name);
+	stem.to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -119,5 +202,160 @@ mod tests {
 		let b = VaultIndex::default();
 		assert_eq!(a.len(), b.len());
 		assert_eq!(a.version(), b.version());
+	}
+
+	fn make_entry(path: &str, links: &[&str]) -> NoteEntry {
+		NoteEntry {
+			path: path.to_string(),
+			title: String::new(),
+			frontmatter: HashMap::new(),
+			outgoing_links: links.iter().map(|s| s.to_string()).collect(),
+			tags: Vec::new(),
+			modified_at: None,
+			word_count: 0,
+			snippet: String::new(),
+		}
+	}
+
+	#[test]
+	fn build_populates_entries_and_by_path() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &[]),
+			make_entry("/v/b.md", &[]),
+		]);
+		assert_eq!(idx.len(), 2);
+		assert!(!idx.is_empty());
+		assert_eq!(idx.entry_for_path("/v/a.md").unwrap().path, "/v/a.md");
+		assert_eq!(idx.entry_for_path("/v/b.md").unwrap().path, "/v/b.md");
+		assert!(idx.entry_for_path("/v/missing.md").is_none());
+	}
+
+	#[test]
+	fn build_bumps_version_each_time() {
+		let mut idx = VaultIndex::new();
+		assert_eq!(idx.version(), 0);
+		idx.build(vec![make_entry("/v/a.md", &[])]);
+		assert_eq!(idx.version(), 1);
+		idx.build(vec![make_entry("/v/a.md", &[]), make_entry("/v/b.md", &[])]);
+		assert_eq!(idx.version(), 2);
+	}
+
+	#[test]
+	fn build_resolves_simple_filename_wikilinks() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/alpha.md", &["beta"]),
+			make_entry("/v/beta.md", &[]),
+		]);
+		let backs = idx.backlinks_of("/v/beta.md");
+		assert_eq!(backs.len(), 1);
+		assert_eq!(backs[0], "/v/alpha.md");
+		assert!(idx.backlinks_of("/v/alpha.md").is_empty());
+	}
+
+	#[test]
+	fn build_resolves_case_insensitive() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/Alpha.md", &["ALPHA"]),
+			make_entry("/v/beta.md", &["alpha"]),
+		]);
+		let backs = idx.backlinks_of("/v/Alpha.md");
+		assert_eq!(backs.len(), 1);
+		assert_eq!(backs[0], "/v/beta.md");
+	}
+
+	#[test]
+	fn build_falls_back_to_basename_for_path_targets() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/beta.md", &["folder/sub/beta"]),
+			make_entry("/v/alpha.md", &[]),
+		]);
+		// The [[folder/sub/beta]] link resolves via basename to /v/beta.md
+		// (a self-link, which is filtered out), NOT to /v/alpha.md.
+		assert!(idx.backlinks_of("/v/beta.md").is_empty());
+	}
+
+	#[test]
+	fn build_ignores_self_links() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_entry("/v/alpha.md", &["alpha"])]);
+		assert!(idx.backlinks_of("/v/alpha.md").is_empty());
+	}
+
+	#[test]
+	fn build_handles_unresolved_targets() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_entry("/v/alpha.md", &["does-not-exist"])]);
+		assert!(idx.backlinks_of("/v/alpha.md").is_empty());
+	}
+
+	#[test]
+	fn build_first_path_wins_on_filename_collision() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/dir1/note.md", &[]),
+			make_entry("/v/dir2/note.md", &[]),
+			make_entry("/v/source.md", &["note"]),
+		]);
+		// Collision: both dir1/note.md and dir2/note.md share stem `note`.
+		// First wins (insertion order): dir1/note.md should be the target.
+		let backs = idx.backlinks_of("/v/dir1/note.md");
+		assert_eq!(backs.len(), 1);
+		assert_eq!(backs[0], "/v/source.md");
+		assert!(idx.backlinks_of("/v/dir2/note.md").is_empty());
+	}
+
+	#[test]
+	fn build_multiple_sources_linking_to_same_target() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["target"]),
+			make_entry("/v/b.md", &["target"]),
+			make_entry("/v/c.md", &["target"]),
+			make_entry("/v/target.md", &[]),
+		]);
+		let mut backs: Vec<&String> = idx.backlinks_of("/v/target.md");
+		backs.sort();
+		assert_eq!(
+			backs
+				.iter()
+				.map(|s| s.as_str())
+				.collect::<Vec<_>>(),
+			vec!["/v/a.md", "/v/b.md", "/v/c.md"]
+		);
+	}
+
+	#[test]
+	fn build_same_source_linking_twice_counts_once() {
+		// a.md has "beta" twice in its outgoing_links (extractor dedupes, but defend against it).
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			NoteEntry {
+				path: "/v/a.md".into(),
+				outgoing_links: vec!["beta".into(), "beta".into()],
+				..Default::default()
+			},
+			make_entry("/v/beta.md", &[]),
+		]);
+		assert_eq!(idx.backlinks_of("/v/beta.md").len(), 1);
+	}
+
+	#[test]
+	fn build_rebuild_replaces_previous_state() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_entry("/v/a.md", &["b"]),
+			make_entry("/v/b.md", &[]),
+		]);
+		assert_eq!(idx.backlinks_of("/v/b.md").len(), 1);
+
+		// Rebuild with a fresh set — old backlinks must not persist.
+		idx.build(vec![make_entry("/v/c.md", &[])]);
+		assert_eq!(idx.len(), 1);
+		assert!(idx.backlinks_of("/v/b.md").is_empty());
+		assert!(idx.entry_for_path("/v/a.md").is_none());
 	}
 }

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -1,0 +1,123 @@
+//! In-memory vault metadata index.
+//!
+//! `VaultIndex` is the single source of truth for note-level metadata after
+//! the performance refactor (ADR 0025). Phase 2.1 establishes the struct
+//! shell — entries + path lookup + reverse backlinks map + monotonic
+//! version counter — and a `Default` / `new` constructor. Subsequent
+//! phase tasks layer behaviour on top:
+//!
+//!   * Phase 2.2 — `VaultIndex::build(entries)` with reverse-index wiring.
+//!   * Phase 2.3 — Tauri managed state so a single `RwLock<VaultIndex>`
+//!     lives for the app lifetime.
+//!   * Phase 2.4 — `get_backlinks_v2` read command.
+//!   * Phase 2.5 — `update_entry(entry)` → `UpdateResult { changed,
+//!     affected }` incremental updater.
+//!   * Phase 2.6 — `update_note_in_index` Tauri command that parses
+//!     content via vault::parsing, calls update_entry, and emits
+//!     `vault-index-updated`.
+//!
+//! Every mutation must go through `update_entry`. Writes that touch
+//! `entries` / `backlinks` / `by_path` directly would let the reverse
+//! index drift — this module rejects that by making those fields
+//! private with getter-only accessors, mirroring the getter-based
+//! Svelte-store pattern in the TS codebase (ADR 0005).
+
+use crate::vault::entry::NoteEntry;
+use std::collections::{HashMap, HashSet};
+
+/// Monotonic revision number. Bumps on every mutation so consumers can
+/// discard stale reads and so `vault-index-updated` payloads carry a
+/// strictly-increasing stamp that clients can order against.
+pub type IndexVersion = u64;
+
+/// In-memory vault metadata index. One entry per markdown note; a reverse
+/// map from "target path" → "source paths that wikilink to it" for O(K)
+/// backlink lookups; and a version stamp.
+///
+/// Construction: `VaultIndex::default()` — empty. Populate with
+/// `VaultIndex::build(entries)` (Phase 2.2). Incrementally update with
+/// `VaultIndex::update_entry(entry)` (Phase 2.5).
+///
+/// Read access is via the `entries()` / `entry_for_path()` / `backlinks_of()`
+/// / `version()` getters. Fields are private so the reverse index cannot
+/// drift out of sync with `entries`.
+#[derive(Debug, Default, Clone)]
+pub struct VaultIndex {
+	entries: Vec<NoteEntry>,
+	by_path: HashMap<String, usize>,
+	backlinks: HashMap<String, HashSet<String>>,
+	version: IndexVersion,
+}
+
+impl VaultIndex {
+	/// Fresh empty index. Version starts at 0; the first `build` or
+	/// `update_entry` bumps to 1.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Read-only slice of all entries, in insertion order. Callers that
+	/// need lookup by path should use `entry_for_path` (O(1)) instead of
+	/// iterating this slice.
+	pub fn entries(&self) -> &[NoteEntry] {
+		&self.entries
+	}
+
+	/// O(1) entry lookup by absolute path, or `None` if no note with that
+	/// path is in the index.
+	pub fn entry_for_path(&self, path: &str) -> Option<&NoteEntry> {
+		self.by_path.get(path).and_then(|i| self.entries.get(*i))
+	}
+
+	/// Number of entries currently in the index.
+	pub fn len(&self) -> usize {
+		self.entries.len()
+	}
+
+	/// True when the index has no entries.
+	pub fn is_empty(&self) -> bool {
+		self.entries.is_empty()
+	}
+
+	/// Returns every source path that has an outgoing wikilink resolving
+	/// to `target_path`. O(1) lookup against the reverse index; returns
+	/// an empty slice when nothing links to `target_path`. The reverse
+	/// index is populated by Phase 2.2's `build` and maintained by Phase
+	/// 2.5's `update_entry`, so this getter returns empty until those
+	/// tasks land.
+	pub fn backlinks_of(&self, target_path: &str) -> Vec<&String> {
+		self.backlinks
+			.get(target_path)
+			.map(|set| set.iter().collect())
+			.unwrap_or_default()
+	}
+
+	/// Current revision number. Bumps on every successful mutation.
+	pub fn version(&self) -> IndexVersion {
+		self.version
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn default_is_empty() {
+		let idx = VaultIndex::default();
+		assert_eq!(idx.len(), 0);
+		assert!(idx.is_empty());
+		assert_eq!(idx.version(), 0);
+		assert!(idx.entries().is_empty());
+		assert!(idx.entry_for_path("/anywhere.md").is_none());
+		assert!(idx.backlinks_of("/anywhere.md").is_empty());
+	}
+
+	#[test]
+	fn new_equals_default() {
+		let a = VaultIndex::new();
+		let b = VaultIndex::default();
+		assert_eq!(a.len(), b.len());
+		assert_eq!(a.version(), b.version());
+	}
+}

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -9,3 +9,14 @@
 pub mod entry;
 pub mod index;
 pub mod parsing;
+
+use std::sync::RwLock;
+
+/// Tauri managed-state wrapper for the singleton `VaultIndex`. Held inside
+/// an `RwLock` so reads (`get_backlinks_v2`, `get_outgoing_links_v2`, etc.)
+/// can execute in parallel while writes (`scan_vault_v2`,
+/// `update_note_in_index`) briefly take the exclusive lock.
+///
+/// Command handlers receive it as `State<'_, VaultIndexState>` and call
+/// `.read()` / `.write()` at the top of the handler.
+pub type VaultIndexState = RwLock<index::VaultIndex>;

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -7,4 +7,5 @@
 //! `tasks/todo/performance-architecture-refactor.md` for the full plan.
 
 pub mod entry;
+pub mod index;
 pub mod parsing;

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -27,7 +27,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 - [x] **2.1** `src-tauri/src/vault/index.rs` (moved from `src-tauri/src/index/` — staying under the `vault/` module to keep related code together): `VaultIndex { entries, by_path, backlinks, version }` with private fields + getter-only access (no drift between entries and reverse index).
 - [x] **2.2** `VaultIndex::build(entries)` computing reverse index. Wikilink resolution mirrors TS `resolveWikilink` exactly: lowercase filename stem + basename-fallback for path-prefixed targets. First path wins on stem collisions. Self-links filtered.
 - [x] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`) via `VaultIndexState` alias in `vault/mod.rs`. `scan_vault_v2` takes `State<'_, VaultIndexState>` and calls `idx.build(...)` after collecting entries.
-- [ ] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`.
+- [x] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`. Sorts results by title for stable UI ordering; filters out entries whose paths are missing from the index (defensive, should not happen in normal operation).
 - [ ] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected }`.
 - [ ] **2.6** `#[tauri::command] update_note_in_index(path, content)` → parse + update_entry + emit `vault-index-updated`.
 

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -24,7 +24,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 
 ### Phase 2 — Rust Backlinks Index (parallel)
 
-- [ ] **2.1** `src-tauri/src/index/mod.rs`: `VaultIndex { entries, by_path, backlinks, version }`.
+- [x] **2.1** `src-tauri/src/vault/index.rs` (moved from `src-tauri/src/index/` — staying under the `vault/` module to keep related code together): `VaultIndex { entries, by_path, backlinks, version }` with private fields + getter-only access (no drift between entries and reverse index).
 - [ ] **2.2** `VaultIndex::build(entries)` computing reverse index with same resolution rules as TS `resolveWikilink` (filename, title, aliases, path suffix).
 - [ ] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`). Initialize on `scan_vault_v2`.
 - [ ] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`.

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -26,7 +26,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 
 - [x] **2.1** `src-tauri/src/vault/index.rs` (moved from `src-tauri/src/index/` — staying under the `vault/` module to keep related code together): `VaultIndex { entries, by_path, backlinks, version }` with private fields + getter-only access (no drift between entries and reverse index).
 - [x] **2.2** `VaultIndex::build(entries)` computing reverse index. Wikilink resolution mirrors TS `resolveWikilink` exactly: lowercase filename stem + basename-fallback for path-prefixed targets. First path wins on stem collisions. Self-links filtered.
-- [ ] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`). Initialize on `scan_vault_v2`.
+- [x] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`) via `VaultIndexState` alias in `vault/mod.rs`. `scan_vault_v2` takes `State<'_, VaultIndexState>` and calls `idx.build(...)` after collecting entries.
 - [ ] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`.
 - [ ] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected }`.
 - [ ] **2.6** `#[tauri::command] update_note_in_index(path, content)` → parse + update_entry + emit `vault-index-updated`.

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -25,7 +25,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 ### Phase 2 — Rust Backlinks Index (parallel)
 
 - [x] **2.1** `src-tauri/src/vault/index.rs` (moved from `src-tauri/src/index/` — staying under the `vault/` module to keep related code together): `VaultIndex { entries, by_path, backlinks, version }` with private fields + getter-only access (no drift between entries and reverse index).
-- [ ] **2.2** `VaultIndex::build(entries)` computing reverse index with same resolution rules as TS `resolveWikilink` (filename, title, aliases, path suffix).
+- [x] **2.2** `VaultIndex::build(entries)` computing reverse index. Wikilink resolution mirrors TS `resolveWikilink` exactly: lowercase filename stem + basename-fallback for path-prefixed targets. First path wins on stem collisions. Self-links filtered.
 - [ ] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`). Initialize on `scan_vault_v2`.
 - [ ] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`.
 - [ ] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected }`.

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -28,7 +28,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 - [x] **2.2** `VaultIndex::build(entries)` computing reverse index. Wikilink resolution mirrors TS `resolveWikilink` exactly: lowercase filename stem + basename-fallback for path-prefixed targets. First path wins on stem collisions. Self-links filtered.
 - [x] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`) via `VaultIndexState` alias in `vault/mod.rs`. `scan_vault_v2` takes `State<'_, VaultIndexState>` and calls `idx.build(...)` after collecting entries.
 - [x] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`. Sorts results by title for stable UI ordering; filters out entries whose paths are missing from the index (defensive, should not happen in normal operation).
-- [ ] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected }`.
+- [x] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected, version }`. Diffs outgoing links vs previous entry state; adds/removes source from target backlinks sets; cleans up empty sets. Self-links filtered.
 - [ ] **2.6** `#[tauri::command] update_note_in_index(path, content)` → parse + update_entry + emit `vault-index-updated`.
 
 ### Phase 3 — Migrate Backlinks Consumers

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -29,7 +29,7 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 - [x] **2.3** Wire `VaultIndex` into Tauri managed state (`RwLock<VaultIndex>`) via `VaultIndexState` alias in `vault/mod.rs`. `scan_vault_v2` takes `State<'_, VaultIndexState>` and calls `idx.build(...)` after collecting entries.
 - [x] **2.4** `#[tauri::command] get_backlinks_v2(path)` → `Vec<NoteEntry>`. Sorts results by title for stable UI ordering; filters out entries whose paths are missing from the index (defensive, should not happen in normal operation).
 - [x] **2.5** `VaultIndex::update_entry` returning `UpdateResult { changed, affected, version }`. Diffs outgoing links vs previous entry state; adds/removes source from target backlinks sets; cleans up empty sets. Self-links filtered.
-- [ ] **2.6** `#[tauri::command] update_note_in_index(path, content)` → parse + update_entry + emit `vault-index-updated`.
+- [x] **2.6** `#[tauri::command] update_note_in_index(path, content)` → parses via Phase 1 extractors, calls `update_entry`, emits `vault-index-updated` carrying the `UpdateResult`. Reads mtime from disk at call time; failed emits are logged but don't fail the mutation (already committed under the write lock). Event name exported as `VAULT_INDEX_UPDATED_EVENT` constant.
 
 ### Phase 3 — Migrate Backlinks Consumers
 


### PR DESCRIPTION
## Summary

Phase 2 of the performance & architecture refactor ([ADR 0025](../blob/claude/phase-1-rust-entry-enrichment/docs/adr/0025-performance-refactor-rust-vault-index.md)). Builds the in-memory Rust `VaultIndex` on top of the Phase 1 `NoteEntry` extractors. After this phase, the backend holds the canonical reverse-backlinks map and exposes read + write Tauri commands, but no TS consumer switches over yet — that's Phase 3.

Depends on: **`claude/phase-1-rust-entry-enrichment`** (base branch). Merge Phase 1 first.

## Commits (6)

| # | Commit | Task |
|---|---|---|
| 2.1 | `cae6cb2` | `VaultIndex` struct shell — private fields, getter-only access so the reverse index can't drift from `entries` |
| 2.2 | `aff4973` | `VaultIndex::build(entries)` — wikilink resolution mirrors TS `resolveWikilink` exactly (filename stem + basename fallback, first-path-wins, self-links filtered) |
| 2.3 | `b315d6b` | Tauri managed state `VaultIndexState = RwLock<VaultIndex>`; `scan_vault_v2` now builds + publishes the index |
| 2.4 | `a54f896` | `get_backlinks_v2(path)` read command |
| 2.5 | `5f65ba3` | `update_entry` — incremental diff-based reverse-map maintenance; returns `UpdateResult { changed, affected, version }` |
| 2.6 | `5559f62` | `update_note_in_index` Tauri command + `vault-index-updated` event (name exported as `VAULT_INDEX_UPDATED_EVENT`) |

## What's in the API

**Read:**
- `invoke<NoteEntry[]>('get_backlinks_v2', { path })` — O(K) via reverse index.

**Write:**
- `invoke<UpdateResult>('update_note_in_index', { path, content })` — parse via Phase 1 extractors → `update_entry` → emit `vault-index-updated`. Intended to be called from the TS editor save path.

**State:**
- Tauri managed `VaultIndexState` (one per process). Readers take `.read()` concurrently; writers (`scan_vault_v2`, `update_note_in_index`) briefly hold `.write()`.

## Architectural contract

- `VaultIndex` fields are **private**; all access goes through `build` / `update_entry` / getters. Reverse index cannot drift out of sync with `entries`.
- Every `update_entry` call bumps `version` by 1 (wrapping) and returns the new version in `UpdateResult`.
- `update_entry` returns `affected` = exactly the set of target paths whose backlinks set **actually changed**. Pure metadata updates (e.g. word_count only) return an empty `affected` so consumer panels don't re-fetch unnecessarily.
- `update_note_in_index` emits `vault-index-updated` after the write lock is released — event delivery cannot block the mutation.

## Test plan

- [ ] Merge Phase 1 to main first.
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` — verifies the 20 `index.rs` unit tests (build + update_entry coverage) + the 84 parsing/entry tests from Phase 1 still pass. **Note:** not run in CI yet; the sandbox used to author this is blocked from fetching `ort-sys` prebuilt ONNX binaries, so tests were validated via `rustc --test` wrapper. On a machine with network the normal `cargo test` will run.
- [ ] `pnpm check` — must remain clean. No TS consumers yet, but `vault-v2.types.ts` shape is unchanged.
- [ ] Smoke-test in-app: open a vault → watch for `[VAULT] scan_vault_v2: <N> entries` in the Rust log → verify no errors.
- [ ] Rust-side only: call `invoke('update_note_in_index', { path, content })` from devtools against a note with a `[[target]]` wikilink → verify `vault-index-updated` event fires (listen in devtools console: `@tauri-apps/api/event listen('vault-index-updated', console.log)`).

## Follow-up (Phase 3 — separate PR)

Consumer migration: the `experimental.rustBacklinks` flag, `vaultStore.vaultIndexVersion`, `active-tab-tracker` branching, `notifyAfterSave` → `update_note_in_index` wiring. Lands on `claude/phase-3-migrate-backlinks-consumers` based on this branch.

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_013tnWXFDz1bQbaDVRmw61um)_