### PR TITLE
Phase 4: Tab-switch rAF cancellation (4.4 only; 4.2 + 4.3 deferred)

### DIFF
--- a/src/lib/core/markdown-editor/MarkdownEditor.svelte
+++ b/src/lib/core/markdown-editor/MarkdownEditor.svelte
@@ -27,6 +27,14 @@
 	let container: HTMLDivElement;
 	let view: EditorView | undefined;
 	let lastTabPath: string | undefined;
+	/**
+	 * Monotonic counter used to cancel stale tab-switch rAF chains. Each new
+	 * invocation of the tab-switch $effect below increments this and captures
+	 * its starting value; the deferred rAF callbacks bail if the counter has
+	 * advanced since they were scheduled. Prevents A→B→C under 100ms from
+	 * queuing three overlapping rAF chains that race on view.dispatch.
+	 */
+	let tabSwitchVersion = 0;
 	/** Whether a tab switch is in progress (suppresses onContentChange from the doc replace) */
 	let isTabSwitching = false;
 	const lineNumbersCompartment = new Compartment();
@@ -213,6 +221,12 @@
 		untrack(() => {
 			if (!view || path === lastTabPath || !path) return;
 
+			// Rapid-switch cancellation. Each invocation bumps the version; the
+			// deferred rAF work captures its starting version and bails if a
+			// newer switch has started since. Without this, switching A→B→C
+			// within 100ms queues three overlapping rAF chains that race on
+			// `view?.dispatch` and produce visible flicker.
+			const mySwitchVersion = ++tabSwitchVersion;
 			const tTabSwitch = perfStart();
 
 			// Detect rename: the old path no longer exists in tabs but the CM doc
@@ -279,6 +293,7 @@
 
 			// Restore scroll position, then force decoration rebuild once viewport is stable
 			requestAnimationFrame(() => {
+				if (mySwitchVersion !== tabSwitchVersion) return;
 				debug('TAB_SWITCH', 'restoring scroll, visibleRanges:', view?.visibleRanges?.map(r => `${r.from}-${r.to}`));
 				if (saved) {
 					view?.scrollDOM.scrollTo(saved.scrollLeft, saved.scrollTop);
@@ -286,6 +301,7 @@
 					view?.scrollDOM.scrollTo(0, 0);
 				}
 				requestAnimationFrame(() => {
+					if (mySwitchVersion !== tabSwitchVersion) return;
 					debug('TAB_SWITCH', 'dispatching forceDecorationRebuild, visibleRanges:', view?.visibleRanges?.map(r => `${r.from}-${r.to}`));
 					const t1 = perfStart();
 					view?.dispatch({ effects: forceDecorationRebuild.of(null) });

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -46,9 +46,9 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 ### Phase 4 — Tab-Switch Pipeline Cleanup
 
 - [ ] **4.1** Baseline `switchTab` breakdown.
-- [ ] **4.2** Remove redundant `forceDecorationRebuild.of(null)` rAF call (line ~288).
-- [ ] **4.3** Combine language reconfigure + doc replace into single `view.dispatch`.
-- [ ] **4.4** Add `AbortController` cancellation for rapid switches.
+- [ ] **4.2** Remove redundant `forceDecorationRebuild.of(null)` rAF call (line ~288). **Deferred** — analysis shows the rebuild is needed because scrollTo happens AFTER the docChanged rebuild; removing it could cause a 150ms decoration lag on large files until scrollDebouncePlugin fires. Requires real-vault validation with the Phase 0 probes.
+- [ ] **4.3** Combine language reconfigure + doc replace into single `view.dispatch`. **Deferred** — `applyLanguageForTab` is async (awaits `getLanguageEffects`); combining requires making the effect body async, which interacts with the Phase 4.4 cancellation pattern. Safer to tackle against real vault with baseline probes.
+- [x] **4.4** Rapid-switch cancellation via a `tabSwitchVersion` counter. Simpler than `AbortController` (no async plumbing, no listener leak). Each effect invocation pre-increments + captures; both rAF callbacks bail when the counter has advanced.
 - [ ] **4.5** Regression test for 100 rapid switches.
 
 ### Phase 5 — Keystroke Reactivity Fix ⚠️ BEHAVIORAL (subtle)


### PR DESCRIPTION
## Summary

Phase 4 of the performance & architecture refactor ([ADR 0025](../blob/claude/phase-1-rust-entry-enrichment/docs/adr/0025-performance-refactor-rust-vault-index.md)). Targeted fix for the tab-switch flicker that happens when the user switches tabs faster than the rAF chain can complete — A→B→C under ~100ms used to queue three overlapping rAF chains that raced on `view.dispatch`.

Ships only the cancellation piece (**4.4**). Tasks 4.2 (remove `forceDecorationRebuild`) and 4.3 (combine dispatches) are **deferred** with rationale — both require real-vault validation with the Phase 0 probes to confirm they don't introduce decoration lag regressions.

Depends on: **`claude/phase-3-migrate-backlinks-consumers`** → Phase 2 → Phase 1 → `main`.

## Commits (2)

| # | Commit | Task |
|---|---|---|
| 4.4 | `a6aefc9` | `tabSwitchVersion` counter cancels stale rAF chains — newest switch wins, older chains bail when counter advances |
| docs | `988e054` | Task file updated: 4.4 done, 4.2 + 4.3 deferred with rationale |

## The fix

Added a module-level `tabSwitchVersion = 0` counter in `MarkdownEditor.svelte`. Each invocation of the tab-switch `$effect`:

```ts
const mySwitchVersion = ++tabSwitchVersion;  // capture local version
// ...schedule rAF callbacks
requestAnimationFrame(() => {
    if (mySwitchVersion !== tabSwitchVersion) return;  // newer switch happened — bail
    // ... do scroll restore
    requestAnimationFrame(() => {
        if (mySwitchVersion !== tabSwitchVersion) return;
        // ... do decoration rebuild
    });
});
```

**Why counter over AbortController:** no async plumbing, no listener-leak concerns on rapid switches, O(1) integer comparison. Closure captures the version via `mySwitchVersion`, so each scheduled callback knows which switch it belongs to.

## Why 4.2 + 4.3 were deferred

Documented in the task file, but TL;DR:

- **4.2 (remove `forceDecorationRebuild`):** Plan claimed redundant, but analysis shows the rebuild happens BEFORE `scrollTo`, so the new viewport position may not have decorations until `scrollDebouncePlugin` fires 150ms later. Removing could cause visible decoration lag on large files.
- **4.3 (combine language + doc dispatch):** `applyLanguageForTab` is async (awaits `getLanguageEffects`). Combining requires making the whole effect body async, which interacts with the Phase 4.4 cancellation pattern. Safer to tackle against real vault with baseline probes.

Both can be tackled in a follow-up PR once the Phase 0 baseline numbers are captured against the real vault.

## Test plan

- [ ] Merge PR stack below first (Phase 1 → 2 → 3).
- [ ] `pnpm check` — clean on this branch.
- [ ] `pnpm vitest run` — 5559 tests pass (no new tests; the effect-level behaviour fix is better tested E2E — see below).
- [ ] Manual: on a large vault, rapidly Cmd+1..Cmd+9 between 3–5 tabs under 100ms. Before: occasional decoration flicker. After: final tab renders cleanly, no visible flicker.
- [ ] (Future, if E2E investment is resumed) 100 rapid tab switches between two tabs — assert no errors and final state is correct. The user has indicated E2E is not a current priority, so deferred.

## Follow-up

- 4.1 and 4.5 are measurement/test tasks; deferred with 4.2/4.3.
- Phase 5 (keystroke reactivity) and Phase 6 (Rust outgoing links) are independent and can land in parallel.

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_013tnWXFDz1bQbaDVRmw61um)_