### PR TITLE
Phase 7 (tags): Rust tag reverse index + get_all_tags_v2 + get_notes_with_tag_v2

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -246,6 +246,38 @@ pub fn get_backlinks_v2(
 	Ok(entries)
 }
 
+/// Aggregate list of every tag in the vault with count + file paths,
+/// sorted by name (case-insensitive). First-occurrence casing preserved
+/// (mirrors TS `aggregateTags`).
+#[tauri::command]
+pub fn get_all_tags_v2(
+	index_state: State<'_, VaultIndexState>,
+) -> Result<Vec<crate::vault::index::TagAggregate>, String> {
+	let idx = index_state
+		.read()
+		.map_err(|_| "VaultIndex lock poisoned".to_string())?;
+	Ok(idx.all_tags())
+}
+
+/// Returns every note (full `NoteEntry`) that carries the given tag.
+/// Lookup is case-insensitive. Sorted by title for stable UI.
+#[tauri::command]
+pub fn get_notes_with_tag_v2(
+	tag: String,
+	index_state: State<'_, VaultIndexState>,
+) -> Result<Vec<NoteEntry>, String> {
+	let idx = index_state
+		.read()
+		.map_err(|_| "VaultIndex lock poisoned".to_string())?;
+	let paths = idx.notes_with_tag(&tag);
+	let mut entries: Vec<NoteEntry> = paths
+		.iter()
+		.filter_map(|p| idx.entry_for_path(p).cloned())
+		.collect();
+	entries.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+	Ok(entries)
+}
+
 /// Scans the supplied `content` (the editor's current buffer, which may differ
 /// from disk when the user is typing) for plain-text mentions of every other
 /// note's title that the source at `path` does NOT already wikilink to.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,8 @@ pub fn run() {
             commands::vault::get_backlinks_v2,
             commands::vault::get_outgoing_links_v2,
             commands::vault::get_outgoing_unlinked_mentions_v2,
+            commands::vault::get_all_tags_v2,
+            commands::vault::get_notes_with_tag_v2,
             commands::vault::update_note_in_index,
             commands::files::read_files_batch,
             commands::search::search_vault,

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -47,6 +47,21 @@ pub struct OutgoingUnlinkedMention {
 	pub count: usize,
 }
 
+/// One aggregate row produced by `all_tags` — a tag that appears in the vault
+/// along with its file count and the preserved first-occurrence casing of
+/// the name. Clients use `count` for the tag tree and `file_paths` for
+/// secondary navigation (panel-side filters).
+///
+/// Matches the TS `TagEntry` shape in
+/// `src/lib/features/tags/tags.types.ts`.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TagAggregate {
+	pub name: String,
+	pub count: usize,
+	pub file_paths: Vec<String>,
+}
+
 /// Outcome of a single `update_entry` call, carried as the payload of the
 /// `vault-index-updated` Tauri event (Phase 2.6). Clients use it to decide
 /// which consumer panels need to re-fetch: a panel showing backlinks for
@@ -85,6 +100,14 @@ pub struct VaultIndex {
 	by_path: HashMap<String, usize>,
 	backlinks: HashMap<String, HashSet<String>>,
 	by_filename: HashMap<String, String>,
+	/// Tag → set of absolute file paths. Keyed by lowercase tag for
+	/// case-insensitive lookup; `tags_display` preserves the original
+	/// casing chosen by the first note that introduced the tag.
+	tags_by_name: HashMap<String, HashSet<String>>,
+	/// Lowercase tag → first-occurrence display casing. Mirrors the TS
+	/// case-insensitive dedup + first-wins casing from
+	/// `tags.logic.ts::aggregateTags`.
+	tags_display: HashMap<String, String>,
 	version: IndexVersion,
 }
 
@@ -124,6 +147,8 @@ impl VaultIndex {
 		}
 
 		self.backlinks.clear();
+		self.tags_by_name.clear();
+		self.tags_display.clear();
 		for entry in &self.entries {
 			for target in &entry.outgoing_links {
 				if let Some(resolved) = resolve_wikilink(target, &self.by_filename) {
@@ -137,6 +162,16 @@ impl VaultIndex {
 						.or_default()
 						.insert(entry.path.clone());
 				}
+			}
+			for tag in &entry.tags {
+				let lower = tag.to_lowercase();
+				self.tags_by_name
+					.entry(lower.clone())
+					.or_default()
+					.insert(entry.path.clone());
+				self.tags_display
+					.entry(lower)
+					.or_insert_with(|| tag.clone());
 			}
 		}
 
@@ -160,13 +195,14 @@ impl VaultIndex {
 		let source_path = entry.path.clone();
 		let new_links = entry.outgoing_links.clone();
 
-		// Snapshot previous outgoing links (if the entry already exists).
-		let prev_links: Vec<String> = self
+		// Snapshot previous outgoing links + tags (if the entry already exists).
+		let (prev_links, prev_tags): (Vec<String>, Vec<String>) = self
 			.by_path
 			.get(&source_path)
 			.and_then(|i| self.entries.get(*i))
-			.map(|e| e.outgoing_links.clone())
+			.map(|e| (e.outgoing_links.clone(), e.tags.clone()))
 			.unwrap_or_default();
+		let new_tags = entry.tags.clone();
 
 		// Replace / insert the entry in the entries vec and by_path.
 		if let Some(idx) = self.by_path.get(&source_path) {
@@ -227,6 +263,35 @@ impl VaultIndex {
 				if set.insert(source_path.clone()) {
 					affected.insert(resolved_owned);
 				}
+			}
+		}
+
+		// Tag diff: drop source from old tags no longer present, insert into new ones.
+		let prev_tag_lower: HashSet<String> =
+			prev_tags.iter().map(|t| t.to_lowercase()).collect();
+		let new_tag_lower: HashSet<String> = new_tags.iter().map(|t| t.to_lowercase()).collect();
+		for tag in prev_tags.iter() {
+			let lower = tag.to_lowercase();
+			if !new_tag_lower.contains(&lower) {
+				if let Some(set) = self.tags_by_name.get_mut(&lower) {
+					set.remove(&source_path);
+					if set.is_empty() {
+						self.tags_by_name.remove(&lower);
+						self.tags_display.remove(&lower);
+					}
+				}
+			}
+		}
+		for tag in new_tags.iter() {
+			let lower = tag.to_lowercase();
+			if !prev_tag_lower.contains(&lower) {
+				self.tags_by_name
+					.entry(lower.clone())
+					.or_default()
+					.insert(source_path.clone());
+				self.tags_display
+					.entry(lower)
+					.or_insert_with(|| tag.clone());
 			}
 		}
 
@@ -345,6 +410,42 @@ impl VaultIndex {
 				.cmp(&b.note_name.to_lowercase())
 		});
 		mentions
+	}
+
+	/// Returns every absolute path of a note that carries the given tag.
+	/// Lookup is case-insensitive; order is unspecified (callers should
+	/// sort if needed). O(1).
+	pub fn notes_with_tag(&self, tag: &str) -> Vec<String> {
+		self.tags_by_name
+			.get(&tag.to_lowercase())
+			.map(|set| set.iter().cloned().collect())
+			.unwrap_or_default()
+	}
+
+	/// Aggregate view of every tag in the vault: display name, file count, and
+	/// full path list. Sorted by name (case-insensitive) for stable UI.
+	/// Mirrors TS `aggregateTags` output.
+	pub fn all_tags(&self) -> Vec<TagAggregate> {
+		let mut out: Vec<TagAggregate> = self
+			.tags_by_name
+			.iter()
+			.map(|(lower, paths)| {
+				let name = self
+					.tags_display
+					.get(lower)
+					.cloned()
+					.unwrap_or_else(|| lower.clone());
+				let mut file_paths: Vec<String> = paths.iter().cloned().collect();
+				file_paths.sort();
+				TagAggregate {
+					count: paths.len(),
+					name,
+					file_paths,
+				}
+			})
+			.collect();
+		out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+		out
 	}
 
 	/// Resolves the outgoing wikilinks of the note at `source_path` to the
@@ -763,6 +864,115 @@ mod tests {
 		]);
 		// `folder/sub/beta` resolves via basename to /v/beta.md.
 		assert_eq!(idx.outgoing_links_of("/v/source.md"), vec!["/v/beta.md".to_string()]);
+	}
+
+	// --- tags aggregation ---
+
+	fn make_tagged(path: &str, tags: &[&str]) -> NoteEntry {
+		NoteEntry {
+			path: path.to_string(),
+			tags: tags.iter().map(|s| s.to_string()).collect(),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn notes_with_tag_returns_paths() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_tagged("/v/a.md", &["work"]),
+			make_tagged("/v/b.md", &["work", "urgent"]),
+			make_tagged("/v/c.md", &["personal"]),
+		]);
+		let mut work = idx.notes_with_tag("work");
+		work.sort();
+		assert_eq!(work, vec!["/v/a.md", "/v/b.md"]);
+		assert_eq!(idx.notes_with_tag("urgent"), vec!["/v/b.md"]);
+		assert!(idx.notes_with_tag("nonexistent").is_empty());
+	}
+
+	#[test]
+	fn notes_with_tag_is_case_insensitive() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_tagged("/v/a.md", &["Work"])]);
+		assert_eq!(idx.notes_with_tag("work"), vec!["/v/a.md"]);
+		assert_eq!(idx.notes_with_tag("WORK"), vec!["/v/a.md"]);
+	}
+
+	#[test]
+	fn all_tags_aggregates_with_first_occurrence_casing() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_tagged("/v/a.md", &["Work"]),
+			make_tagged("/v/b.md", &["work"]),       // Lowercase — but "Work" should persist
+			make_tagged("/v/c.md", &["Personal"]),
+		]);
+		let all = idx.all_tags();
+		assert_eq!(all.len(), 2);
+		let work = all.iter().find(|t| t.name == "Work").expect("Work case preserved");
+		assert_eq!(work.count, 2);
+		assert_eq!(work.file_paths.len(), 2);
+	}
+
+	#[test]
+	fn all_tags_sorted_case_insensitive() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![
+			make_tagged("/v/a.md", &["Zebra"]),
+			make_tagged("/v/b.md", &["alpha"]),
+			make_tagged("/v/c.md", &["Mango"]),
+		]);
+		let all = idx.all_tags();
+		assert_eq!(
+			all.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+			vec!["alpha", "Mango", "Zebra"]
+		);
+	}
+
+	#[test]
+	fn update_entry_diffs_tags() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_tagged("/v/a.md", &["old1", "old2"])]);
+		assert_eq!(idx.notes_with_tag("old1"), vec!["/v/a.md"]);
+		assert_eq!(idx.notes_with_tag("old2"), vec!["/v/a.md"]);
+
+		idx.update_entry(make_tagged("/v/a.md", &["old1", "new1"]));
+		assert_eq!(idx.notes_with_tag("old1"), vec!["/v/a.md"]);
+		assert!(idx.notes_with_tag("old2").is_empty());
+		assert_eq!(idx.notes_with_tag("new1"), vec!["/v/a.md"]);
+	}
+
+	#[test]
+	fn update_entry_cleans_up_empty_tag_sets() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_tagged("/v/a.md", &["solo"])]);
+		assert_eq!(idx.all_tags().len(), 1);
+
+		idx.update_entry(make_tagged("/v/a.md", &[]));
+		assert!(idx.all_tags().is_empty());
+	}
+
+	#[test]
+	fn update_entry_insert_with_new_tag_registers_display() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_tagged("/v/a.md", &["Alpha"])]);
+		idx.update_entry(make_tagged("/v/b.md", &["alpha"]));
+		let all = idx.all_tags();
+		assert_eq!(all.len(), 1);
+		assert_eq!(all[0].name, "Alpha"); // first-occurrence casing preserved across updates
+		assert_eq!(all[0].count, 2);
+	}
+
+	#[test]
+	fn build_rebuilds_tag_index_from_scratch() {
+		let mut idx = VaultIndex::new();
+		idx.build(vec![make_tagged("/v/a.md", &["old"])]);
+		assert_eq!(idx.notes_with_tag("old"), vec!["/v/a.md"]);
+
+		// Rebuild with different entries — old tags must be cleared.
+		idx.build(vec![make_tagged("/v/b.md", &["new"])]);
+		assert!(idx.notes_with_tag("old").is_empty());
+		assert_eq!(idx.notes_with_tag("new"), vec!["/v/b.md"]);
 	}
 
 	// --- outgoing_unlinked_mentions_of ---

--- a/tasks/todo/performance-architecture-refactor.md
+++ b/tasks/todo/performance-architecture-refactor.md
@@ -69,12 +69,14 @@ Full plan context: `/root/.claude/plans/performance-architecture-buzzing-cray.md
 
 ### Phase 7 — Rust Tag & Task Indexes
 
-- [ ] **7.1** Extend `VaultIndex` with `tags`, `tasks`.
+- [x] **7.1a (tags)** Added `tags_by_name: HashMap<String, HashSet<String>>` (lowercase-keyed) + `tags_display: HashMap<String, String>` (first-occurrence casing) to `VaultIndex`. Populated in `build`; maintained in `update_entry` via tag diff (drops source from old tags, inserts into new, cleans up empty sets, preserves display casing across replacements). Getters: `notes_with_tag(tag)` (O(1)) + `all_tags() -> Vec<TagAggregate>`.
+- [ ] **7.1b (tasks)** Extend `VaultIndex` with `tasks: HashMap<String, Vec<TaskEntry>>`. Deferred — task extraction is substantial new work (checkbox regex + TaskMetadata emoji signifiers + indent calc + ordered/unordered markers).
 - [ ] **7.2** `extract_tasks` (checkboxes, statuses, line numbers, due dates).
-- [ ] **7.3** Wire into `update_entry` with `vault-index-updated`.
-- [ ] **7.4** Read commands: `get_notes_with_tag`, `get_all_tags`, `get_all_tasks`, `get_tasks_in_path`.
+- [ ] **7.3** Wire into `update_entry` with `vault-index-updated` (tags portion done as part of 7.1a).
+- [x] **7.4a (tag read commands)** `get_all_tags_v2` + `get_notes_with_tag_v2(tag) -> Vec<NoteEntry>`.
+- [ ] **7.4b (task read commands)** `get_all_tasks`, `get_tasks_in_path`.
 - [ ] **7.5** Write commands: `rename_tag`, `add_tag_to_note`, `remove_tag_from_note`, `toggle_task_status`.
-- [ ] **7.6** `experimental.rustTagsAndTasks` flag; migrate Tags + Tasks panels.
+- [ ] **7.6** `experimental.rustTagsAndTasks` flag (already defined in Phase 3.1); migrate Tags + Tasks panels.
 - [ ] **7.7** Enable + delete orphans.
 
 ### Phase 8 — Rust Frontmatter / Properties Index + File Ops


### PR DESCRIPTION
## Summary

Phase 7 (tags portion) of the performance & architecture refactor ([ADR 0025](../blob/claude/phase-1-rust-entry-enrichment/docs/adr/0025-performance-refactor-rust-vault-index.md)). Adds a reverse-index for tags on the Rust `VaultIndex` + two read commands so the Tags Panel can migrate to the consumer pattern in a later PR.

Phase 7 is naturally split into **tags-first** (this PR) + **tasks-follow-up**. Task extraction needs substantial new Rust work (checkbox regex, `TaskMetadata` emoji signifier parser, indent calc, ordered/unordered marker support) — scoping that separately keeps this PR reviewable.

Depends on: **`claude/phase-6-rust-outgoing-links`** → Phase 4 → Phase 3 → Phase 2 → Phase 1 → `main`.

## Commits (2)

| # | Commit | Task |
|---|---|---|
| 7.1a + 7.4a | `19a909b` | Tag reverse index + display-casing map + `get_all_tags_v2` + `get_notes_with_tag_v2` |
| docs | `b7a8bc8` | Task file catch-up (split tags / tasks) |

## New API

**Struct:**
```rust
#[derive(Serialize)]
#[serde(rename_all = "camelCase")]
pub struct TagAggregate {
    pub name: String,       // first-occurrence display casing
    pub count: usize,
    pub file_paths: Vec<String>,
}
```
Matches TS `TagEntry` in `tags.types.ts`.

**Commands:**
```rust
#[tauri::command]
pub fn get_all_tags_v2(state) -> Result<Vec<TagAggregate>, String>;

#[tauri::command]
pub fn get_notes_with_tag_v2(tag: String, state) -> Result<Vec<NoteEntry>, String>;
```

## Internals

Two new private fields on `VaultIndex`:

```rust
tags_by_name:   HashMap<String, HashSet<String>>,  // lowercase → paths
tags_display:   HashMap<String, String>,           // lowercase → display casing
```

- `build()` populates both from scratch (clears on rebuild).
- `update_entry()` diffs previous vs new `entry.tags`. Lowercase dedup. For each removed tag: drops the source from `tags_by_name`; if the set becomes empty, drops the display entry too. For each added tag: inserts into `tags_by_name`; only inserts into `tags_display` if the lowercase key is new to the vault, so a case flip on an existing tag doesn't silently change the canonical display casing.

## Architectural patterns preserved

- Consumer panel pattern stays identical: Tags Panel in a later PR will `$effect(activePath + vaultIndexVersion) → invoke('get_all_tags_v2') → render`.
- `vault-index-updated` already fires on every `update_entry` (Phase 2.6), so tag mutations automatically trigger the panel re-fetch — no new event or flag wiring needed on this PR.
- `experimental.rustTagsAndTasks` flag already exists (Phase 3.1). Phase 7.6 will branch the Tags Panel on it; the command is live but unused until then.

## Test plan

- [ ] Merge stack below first.
- [ ] `cargo test` clean in a normal build environment (sandbox blocks `ort-sys` — 140 vault-module tests verified via `rustc --test` wrapper).
- [ ] `pnpm check` clean.
- [ ] New tag-specific coverage (8 tests): `notes_with_tag` returns paths + empty for nonexistent, case-insensitive lookup, `all_tags` preserves first-occurrence casing across multiple entries with same tag, sorted case-insensitive, `update_entry` diffs tags (remove old / add new), empty tag sets cleaned up, insert with existing tag preserves display casing, `build` rebuilds cleanly replacing previous state.
- [ ] No consumer invokes the new commands yet — runtime behaviour unchanged.

## Follow-up (separate PRs, same Phase 7)

- **7.1b + 7.2 + 7.3 (tasks portion):** `extract_tasks` in `vault/parsing.rs` (checkbox / fence / indent / TaskMetadata port); `tasks` HashMap on `VaultIndex`; `update_entry` task diff.
- **7.4b:** `get_all_tasks`, `get_tasks_in_path`.
- **7.5:** Write commands — `rename_tag`, `add_tag_to_note`, `remove_tag_from_note`, `toggle_task_status`.
- **7.6:** Branch Tags + Tasks panels on `experimental.rustTagsAndTasks`.
- **7.7:** Enable flag by default + delete TS orphans.

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_013tnWXFDz1bQbaDVRmw61um)_