### PR TITLE
feat(settings): QueryJS section with autoRunQueries dropdown

### DIFF
--- a/src/lib/core/settings/SettingsDialog.svelte
+++ b/src/lib/core/settings/SettingsDialog.svelte
@@ -23,6 +23,7 @@
 	import SecuritySection from './sections/SecuritySection.svelte';
 	import TroubleshootingSection from './sections/TroubleshootingSection.svelte';
 	import UpdateSection from './sections/UpdateSection.svelte';
+	import QueryjsSection from './sections/QueryjsSection.svelte';
 	import PaletteIcon from '@lucide/svelte/icons/palette';
 	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
 	import PencilLineIcon from '@lucide/svelte/icons/pencil-line';
@@ -39,6 +40,7 @@
 	import ShieldIcon from '@lucide/svelte/icons/shield';
 	import BugIcon from '@lucide/svelte/icons/bug';
 	import DownloadIcon from '@lucide/svelte/icons/download';
+	import Code2Icon from '@lucide/svelte/icons/code-2';
 	import type { SettingsSection } from './settings.types';
 	import type { Component } from 'svelte';
 
@@ -59,6 +61,7 @@
 		security: ShieldIcon,
 		troubleshooting: BugIcon,
 		update: DownloadIcon,
+		queryjs: Code2Icon,
 	};
 
 	const debouncedSave = debounce(() => {
@@ -212,6 +215,8 @@
 					<TroubleshootingSection onchange={debouncedSave} />
 				{:else if settingsDialogStore.activeSection === 'update'}
 					<UpdateSection />
+				{:else if settingsDialogStore.activeSection === 'queryjs'}
+					<QueryjsSection onchange={debouncedSave} />
 				{/if}
 			</div>
 		</ScrollArea>

--- a/src/lib/core/settings/sections/QueryjsSection.svelte
+++ b/src/lib/core/settings/sections/QueryjsSection.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select';
+	import { settingsStore } from '../settings.store.svelte';
+	import { queryjsSessionStore } from '$lib/plugins/queryjs/queryjs-session.store.svelte';
+	import type { AutoRunQueriesPolicy } from '../settings.types';
+	import SettingItem from './SettingItem.svelte';
+
+	let { onchange }: { onchange: () => void } = $props();
+
+	const POLICY_OPTIONS: { value: AutoRunQueriesPolicy; label: string; description: string }[] = [
+		{
+			value: 'first-open',
+			label: 'First open',
+			description: 'Run on the first time the file opens this session, then cache.',
+		},
+		{
+			value: 'always',
+			label: 'Always',
+			description: 'Re-run on every render. Slower but always fresh.',
+		},
+		{
+			value: 'manual',
+			label: 'Manual',
+			description: 'Never auto-execute. Use ▶ Run on each block.',
+		},
+	];
+
+	function policyLabel(value: AutoRunQueriesPolicy): string {
+		return POLICY_OPTIONS.find((o) => o.value === value)?.label ?? value;
+	}
+
+	function policyDescription(value: AutoRunQueriesPolicy): string {
+		return POLICY_OPTIONS.find((o) => o.value === value)?.description ?? '';
+	}
+
+	function handlePolicyChange(value: string) {
+		settingsStore.updateQueryjs({ autoRunQueries: value as AutoRunQueriesPolicy });
+		onchange();
+	}
+
+	function clearCache() {
+		queryjsSessionStore.reset();
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	<h2 class="mb-1 text-lg font-semibold">QueryJS</h2>
+	<p class="mb-4 text-xs text-muted-foreground">
+		QueryJS lets you embed JavaScript queries inside notes via <code>```queryjs</code> fenced
+		blocks. The KBAPI surface (<code>kb.pages</code>, <code>kb.view</code>, <code>kb.ui</code>,
+		<code>DataArray</code>, <code>KBDateTime</code>) is documented in the README.
+	</p>
+
+	<SettingItem
+		label="Auto-run policy"
+		description={policyDescription(settingsStore.queryjs.autoRunQueries)}
+	>
+		<Select.Root
+			type="single"
+			value={settingsStore.queryjs.autoRunQueries}
+			onValueChange={handlePolicyChange}
+		>
+			<Select.Trigger size="sm" class="w-44">
+				<span data-slot="select-value">{policyLabel(settingsStore.queryjs.autoRunQueries)}</span>
+			</Select.Trigger>
+			<Select.Content>
+				{#each POLICY_OPTIONS as opt (opt.value)}
+					<Select.Item value={opt.value} label={opt.label} />
+				{/each}
+			</Select.Content>
+		</Select.Root>
+	</SettingItem>
+
+	<SettingItem
+		label="Clear cache"
+		description="Drop all cached query results + autoRun markers for this session. Each block re-runs on its next render (according to the policy above)."
+	>
+		<button
+			type="button"
+			class="rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+			onclick={clearCache}
+		>
+			Clear
+		</button>
+	</SettingItem>
+</div>

--- a/src/lib/core/settings/settings.logic.ts
+++ b/src/lib/core/settings/settings.logic.ts
@@ -94,6 +94,7 @@ export const SETTINGS_SECTION_GROUPS: readonly SettingsSectionGroup[] = [
 			{ id: 'auto-move', label: 'Auto Move' },
 			{ id: 'trash', label: 'Trash' },
 			{ id: 'terminal', label: 'Terminal' },
+			{ id: 'queryjs', label: 'QueryJS' },
 		],
 	},
 	{

--- a/src/lib/core/settings/settings.types.ts
+++ b/src/lib/core/settings/settings.types.ts
@@ -196,7 +196,7 @@ export interface QueryjsSettings {
 }
 
 /** Sidebar navigation sections in the settings dialog */
-export type SettingsSection = 'appearance' | 'sidebar' | 'editor' | 'periodic-notes' | 'quick-note' | 'one-on-one' | 'templates' | 'terminal' | 'search' | 'file-history' | 'auto-move' | 'trash' | 'todoist' | 'security' | 'troubleshooting' | 'update';
+export type SettingsSection = 'appearance' | 'sidebar' | 'editor' | 'periodic-notes' | 'quick-note' | 'one-on-one' | 'templates' | 'terminal' | 'search' | 'file-history' | 'auto-move' | 'trash' | 'todoist' | 'queryjs' | 'security' | 'troubleshooting' | 'update';
 
 /** Top-level settings object persisted as `.kokobrain/settings.json` inside the vault */
 export interface AppSettings {

--- a/src/tests/lib/core/settings/settings.logic.test.ts
+++ b/src/tests/lib/core/settings/settings.logic.test.ts
@@ -243,7 +243,7 @@ describe('SETTINGS_SECTION_GROUPS', () => {
 
 	it('contains all expected sections in order', () => {
 		const ids = SETTINGS_SECTION_GROUPS.flatMap((g) => g.sections.map((s) => s.id));
-		expect(ids).toEqual(['appearance', 'editor', 'sidebar', 'periodic-notes', 'quick-note', 'one-on-one', 'templates', 'search', 'file-history', 'auto-move', 'trash', 'terminal', 'todoist', 'security', 'troubleshooting', 'update']);
+		expect(ids).toEqual(['appearance', 'editor', 'sidebar', 'periodic-notes', 'quick-note', 'one-on-one', 'templates', 'search', 'file-history', 'auto-move', 'trash', 'terminal', 'queryjs', 'todoist', 'security', 'troubleshooting', 'update']);
 	});
 
 	it('has labels for every section', () => {


### PR DESCRIPTION
## Summary

- Adds Settings → Tools → **QueryJS** section exposing the `queryjs.autoRunQueries` policy as a dropdown (`First open` / `Always` / `Manual`).
- Adds a "Clear cache" button that wipes the queryjs session cache + autoRun markers — useful when iterating on queries.
- Closes the user-facing UI gap from the Phase 12 refactor (the policy existed but was settings.json-only).

## Test plan

- [x] `pnpm check && pnpm vitest run` — 5584 passing
- [ ] Open Settings → Tools → QueryJS → pick a policy → verify it persists across app restart
- [ ] On `Manual`: every queryjs block on a freshly-opened note shows ▶ Run
- [ ] On `First open`: first render auto-runs, subsequent renders cache hit, edits show ▶ Run
- [ ] On `Always`: every render re-executes the script
- [ ] Click "Clear cache" → next queryjs block render goes through the policy fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)