### PR TITLE
chore(deps): bump tokenizers from 0.22 to 0.23 (round 2 task 1)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -909,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,13 +5724,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ zeroize = "1"
 ort = { version = "2.0.0-rc.12", features = ["download-binaries", "ndarray", "half"] }
 half = "2.7"
 ndarray = "0.17"
-tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
+tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
 reqwest = { version = "0.13", features = ["stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "fs", "io-util"] }

--- a/tasks/todo/deps-update-round-2-majors.md
+++ b/tasks/todo/deps-update-round-2-majors.md
@@ -1,0 +1,26 @@
+# Dependency Update — Round 2 (majors)
+
+Land each remaining major bump in its own branch + PR so risk is isolated and easy to revert. Order chosen by blast radius (smallest first).
+
+## Tasks
+
+- [ ] Task 1: Rust `tokenizers` 0.22 → 0.23. Branch `claude/deps-round-2-tokenizers`. Used only in `src-tauri/src/semantic/embedder.rs`.
+- [ ] Task 2: Rust `sysinfo` 0.38 → 0.39. Branch `claude/deps-round-2-sysinfo`. Used only in `src-tauri/src/commands/debug.rs`.
+- [ ] Task 3: Rust `sha2` 0.10 → 0.11. Branch `claude/deps-round-2-sha2`. Used in 4 files (history, semantic chunker, semantic command, crypto) but trivial `Digest` + `Sha256::digest/new()` calls.
+- [ ] Task 4: NPM `marked` 17 → 18. Branch `claude/deps-round-2-marked`. Markdown HTML rendering library — verify CHANGELOG.
+- [ ] Task 5: NPM unify lucide family on 1.x (`lucide-svelte`, `@lucide/svelte`, `lucide-static`). Branch `claude/deps-round-2-lucide`. Touches every icon import site — mechanical but wide.
+- [ ] Task 6: NPM `@doist/todoist-sdk` 9 → 10. Branch `claude/deps-round-2-todoist`. Affects the Todoist plugin only.
+
+## Process per task
+
+1. Branch off latest `main` (`git fetch && git checkout -b <branch> origin/main`).
+2. Bump the dep, fix any compilation/type/test breakage.
+3. Run the relevant test command (rust-only → `cargo test`; npm-only → `pnpm check` + `pnpm vitest run`).
+4. Commit with the full Conventional Commits format.
+5. Push branch and open a PR — let CI confirm. User merges when green.
+6. After merge, sync `main` locally before starting the next task.
+
+## Notes
+
+- Each task is independent. If one fails CI, leave the branch open and move on.
+- Don't batch multiple majors into a single PR — defeats the purpose of isolating risk.

--- a/tasks/todo/deps-update-round-2-majors.md
+++ b/tasks/todo/deps-update-round-2-majors.md
@@ -4,7 +4,7 @@ Land each remaining major bump in its own branch + PR so risk is isolated and ea
 
 ## Tasks
 
-- [ ] Task 1: Rust `tokenizers` 0.22 → 0.23. Branch `claude/deps-round-2-tokenizers`. Used only in `src-tauri/src/semantic/embedder.rs`.
+- [x] Task 1: Rust `tokenizers` 0.22 → 0.23. Branch `claude/deps-round-2-tokenizers`. Used only in `src-tauri/src/semantic/embedder.rs`.
 - [ ] Task 2: Rust `sysinfo` 0.38 → 0.39. Branch `claude/deps-round-2-sysinfo`. Used only in `src-tauri/src/commands/debug.rs`.
 - [ ] Task 3: Rust `sha2` 0.10 → 0.11. Branch `claude/deps-round-2-sha2`. Used in 4 files (history, semantic chunker, semantic command, crypto) but trivial `Digest` + `Sha256::digest/new()` calls.
 - [ ] Task 4: NPM `marked` 17 → 18. Branch `claude/deps-round-2-marked`. Markdown HTML rendering library — verify CHANGELOG.


### PR DESCRIPTION
## Summary

- Round 2 of the dependency refresh, task 1.
- Bumps Rust `tokenizers` from 0.22 to 0.23 (resolves to 0.23.1, the first proper stable in that line — see [release notes](https://github.com/huggingface/tokenizers/releases/tag/v0.23.1)).
- No source changes — the public Rust API surface used by this project (`Tokenizer::from_file`, `encode_batch`, `get_ids`/`get_attention_mask`/`get_type_ids`) was untouched.

## Why

Plan: [tasks/todo/deps-update-round-2-majors.md](https://github.com/diegorv/koko.brain/blob/claude/deps-round-2-tokenizers/tasks/todo/deps-update-round-2-majors.md). Each major bump in round 2 ships in its own PR so risk is isolated and easy to revert. This is the smallest one (1 consumer file).

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — all suites green locally
- [ ] CI: Cargo Audit, Rust Tests, Supply Chain Quarantine
- [ ] Manual: confirm semantic search still embeds correctly after merge (next time the app indexes a vault)