### PR TITLE
chore(deps): bump marked from 17 to 18 (round 2 task 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lowlight": "^3.3.0",
     "lucide-static": "^0.577.0",
     "lucide-svelte": "^0.577.0",
-    "marked": "^17.0.6",
+    "marked": "^18.0.3",
     "mermaid": "^11.14.0",
     "simple-icons": "^16.18.1",
     "svelte-sonner": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(svelte@5.55.5(@typescript-eslint/types@8.58.0))
       marked:
-        specifier: ^17.0.6
-        version: 17.0.6
+        specifier: ^18.0.3
+        version: 18.0.3
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -1880,8 +1880,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  marked@17.0.6:
-    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+  marked@18.0.3:
+    resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -4056,7 +4056,7 @@ snapshots:
 
   marked@16.4.2: {}
 
-  marked@17.0.6: {}
+  marked@18.0.3: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/tasks/todo/deps-update-round-2-majors.md
+++ b/tasks/todo/deps-update-round-2-majors.md
@@ -7,7 +7,7 @@ Land each remaining major bump in its own branch + PR so risk is isolated and ea
 - [x] Task 1: Rust `tokenizers` 0.22 → 0.23. Branch `claude/deps-round-2-tokenizers`. Used only in `src-tauri/src/semantic/embedder.rs`.
 - [~] Task 2: Rust `sysinfo` 0.38 → 0.39. **Deferred** — sysinfo 0.39 requires Rust 1.95 (MSRV bump) and the local toolchain is on 1.93. Revisit after `rustup update`. New APIs (operational_state, cgroup_limits) are not used by this project.
 - [x] Task 3: Rust `sha2` 0.10 → 0.11. Branch `claude/deps-round-2-sha2`. `digest 0.11` switched `Sha256::digest` return type from `GenericArray` (which impl'd `LowerHex`) to `Array` (which doesn't), so two `format!("{:x}", …)` call sites were inlined to `iter().map(|b| format!("{:02x}", b)).collect()` (same byte-by-byte hex pattern already used elsewhere in the codebase).
-- [ ] Task 4: NPM `marked` 17 → 18. Branch `claude/deps-round-2-marked`. Markdown HTML rendering library — verify CHANGELOG.
+- [x] Task 4: NPM `marked` 17 → 18. Branch `claude/deps-round-2-marked`. Markdown HTML rendering library — verify CHANGELOG.
 - [ ] Task 5: NPM unify lucide family on 1.x (`lucide-svelte`, `@lucide/svelte`, `lucide-static`). Branch `claude/deps-round-2-lucide`. Touches every icon import site — mechanical but wide.
 - [ ] Task 6: NPM `@doist/todoist-sdk` 9 → 10. Branch `claude/deps-round-2-todoist`. Affects the Todoist plugin only.
 


### PR DESCRIPTION
## Summary

- Round 2 of the dependency refresh, task 4.
- Bumps `marked` from 17.0.6 to 18.0.3.
- Single breaking change in 18.0.0: trailing blank lines are trimmed from block tokens. Doesn't affect this project — only consumer is canvas markdown rendering, where output is sanitized and rendered as HTML.

## Test plan

- [x] `pnpm check` — 0 type errors
- [x] `pnpm vitest run` — 5481 tests passing
- [ ] CI: TypeScript Check, Frontend Tests, npm Audit

## Consumer

- `src/lib/features/canvas/canvas-markdown.logic.ts` — only call site; uses `new Marked({ gfm, breaks })` and `marked.parse(text, { async: false })`. Both APIs unchanged.