### PR TITLE
chore(deps): bump @doist/todoist-sdk from 9 to 10 (round 2 task 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@codemirror/search": "^6.7.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.1",
-    "@doist/todoist-sdk": "^9.8.0",
+    "@doist/todoist-sdk": "^10.1.1",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
     "@fortawesome/free-regular-svg-icons": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^6.41.1
         version: 6.41.1
       '@doist/todoist-sdk':
-        specifier: ^9.8.0
-        version: 9.8.0(type-fest@4.41.0)
+        specifier: ^10.1.1
+        version: 10.1.1(type-fest@4.41.0)
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.2.0
         version: 7.2.0
@@ -433,8 +433,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@doist/todoist-sdk@9.8.0':
-    resolution: {integrity: sha512-qCXWlV3BTZfF9xhgs4slHttf9kna4F0HN16+S4osbc8WxNNcZlzbre8PzewWuVyd4RskcGyMsEogZLZC8U/0Gg==}
+  '@doist/todoist-sdk@10.1.1':
+    resolution: {integrity: sha512-V60AjoJG5QjiJ2iYB8IIC4hLA4B5PLUybYysc1GU2qC3xjN7Zy3juRukKo8PO+O1VMXeb8EACMri5U/0GPnLkA==}
     engines: {node: '>=20.18.1'}
     peerDependencies:
       type-fest: ^4.12.0 || ^5.5.0
@@ -2664,7 +2664,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@doist/todoist-sdk@9.8.0(type-fest@4.41.0)':
+  '@doist/todoist-sdk@10.1.1(type-fest@4.41.0)':
     dependencies:
       camelcase: 6.3.0
       emoji-regex: 10.6.0

--- a/tasks/todo/deps-update-round-2-majors.md
+++ b/tasks/todo/deps-update-round-2-majors.md
@@ -9,7 +9,7 @@ Land each remaining major bump in its own branch + PR so risk is isolated and ea
 - [x] Task 3: Rust `sha2` 0.10 → 0.11. Branch `claude/deps-round-2-sha2`. `digest 0.11` switched `Sha256::digest` return type from `GenericArray` (which impl'd `LowerHex`) to `Array` (which doesn't), so two `format!("{:x}", …)` call sites were inlined to `iter().map(|b| format!("{:02x}", b)).collect()` (same byte-by-byte hex pattern already used elsewhere in the codebase).
 - [x] Task 4: NPM `marked` 17 → 18. Branch `claude/deps-round-2-marked`. Markdown HTML rendering library — verify CHANGELOG.
 - [x] Task 5: NPM unify lucide family on 1.x (`lucide-svelte`, `@lucide/svelte`, `lucide-static`). Branch `claude/deps-round-2-lucide`. Bumped all three packages to 1.x — zero source changes needed (no icons we use were renamed/removed; `pnpm check` clean, all 5481 tests passing).
-- [ ] Task 6: NPM `@doist/todoist-sdk` 9 → 10. Branch `claude/deps-round-2-todoist`. Affects the Todoist plugin only.
+- [x] Task 6: NPM `@doist/todoist-sdk` 9 → 10. Branch `claude/deps-round-2-todoist`. Pinned at 10.1.1 (10.1.2 / 10.1.3 fail the 7-day quarantine). 10.0 breaking change only typed `ProductivityStats` goal flags / ignoreDays — not used by this codebase (only `TodoistApi`, `CustomFetch`, `CustomFetchResponse`, `AddTaskArgs` are imported).
 
 ## Process per task
 


### PR DESCRIPTION
## Summary

- Round 2 of the dependency refresh, **last task**.
- Bumps `@doist/todoist-sdk` from 9.8.0 to 10.1.1.
- Pinned at 10.1.1 (instead of 10.1.3) because 10.1.2 / 10.1.3 fail the repo's 7-day supply chain quarantine.
- 10.0 breaking change is just typing for `ProductivityStats` (goal flags, ignoreDays) — not used here.

## Test plan

- [x] `pnpm check` — 0 type errors
- [x] `pnpm vitest run` — 5481 tests passing
- [ ] CI: TypeScript Check, Frontend Tests, npm Audit

## Round 2 wrap-up

After this PR merges, the only deferred bump from round 2 is `sysinfo` 0.38 → 0.39 (requires Rust 1.95 — local toolchain on 1.93). Worth revisiting after `rustup update`.