### PR TITLE
chore(deps): bump sysinfo from 0.38 to 0.39 (round 2 deferred task)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5122,9 +5122,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
 dependencies = [
  "libc",
  "memchr",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1"
 notify = "8"
 
 # Debug / metrics
-sysinfo = { version = "0.38", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 
 # Shared infrastructure
 chrono = "0.4"


### PR DESCRIPTION
## Summary

- Closes the last deferred bump from round 2 — `sysinfo` 0.38 → 0.39.
- Was blocked because 0.39 raised MSRV to Rust 1.95. Local toolchain has been updated (`rustup update stable` → rustc 1.95.0) and CI already runs on stable, so the upgrade is now drop-in.
- No source changes — `src-tauri/src/commands/debug.rs` only uses APIs untouched by the bump.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — all suites green
- [x] `pnpm check` — 0 type errors
- [x] `pnpm vitest run` — 5481 tests passing
- [ ] CI: Cargo Audit, Rust Tests, Supply Chain Quarantine

## Related: pre-existing E2E mock regression

While running the full test matrix locally I noticed `bash scripts/e2e.sh` fails on `main` (and on this branch — confirmed not introduced here) with:

```
"Resource" is not exported by "e2e/mocks/tauri-core.ts".
"Channel" is not exported by "e2e/mocks/tauri-core.ts".
```

`@tauri-apps/plugin-updater@2.10.1` now imports `Resource` and `Channel` from `@tauri-apps/api/core`, but the e2e mock at `e2e/mocks/tauri-core.ts` is stale. Worth a separate small PR — out of scope for this dep bump.