### PR TITLE
ci: move rust tests to Linux, keep fonts coverage on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,24 +130,58 @@ jobs:
     name: Rust (cargo test)
     needs: changes
     if: needs.changes.outputs.rust == 'true'
-    # macos-latest, not ubuntu, because several modules are gated on
-    # `#[cfg(target_os = "macos")]` and would be silently skipped on
-    # Linux: `src/security/biometric.rs` (Touch ID via LocalAuthentication),
-    # `src/security/keychain.rs` (Keychain Access via security-framework),
-    # `src/commands/fonts.rs` (CoreText system-font enumeration), plus
-    # the macOS-only test at `tests/commands/fonts_test.rs`. The project
-    # ships macOS-only, so a Linux runner would give a false-green on
-    # the platform the binary actually targets.
-    runs-on: macos-latest
+    # Linux for the main suite: cheaper minutes, faster queue. After
+    # the encrypted-notes removal (commit b562224) the only remaining
+    # `#[cfg(target_os = "macos")]` surface is `src/commands/fonts.rs`
+    # (CoreText FFI), which has a `#[cfg(not(target_os = "macos"))]`
+    # fallback returning `Ok(vec![])` so the crate compiles on Linux.
+    # The macOS-only tests at `tests/commands/fonts_test.rs` are wholly
+    # gated and excluded from this run; the `rust-fonts-macos` job below
+    # picks them up on macos-latest so CoreText behavior is still
+    # validated on every PR touching `src-tauri/**`.
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          # The setup action defaults `rust-targets` to
+          # `aarch64-apple-darwin` for the release/nightly macOS builds.
+          # On a Linux runner we only need the host toolchain — passing
+          # an empty value skips the cross-target install that rustup
+          # would otherwise do unnecessarily.
+          rust-targets: ""
 
       - name: Run tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  rust-fonts-macos:
+    name: Rust (cargo test — macOS fonts)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    # `src/commands/fonts.rs` uses CoreText FFI and its tests
+    # (`tests/commands/fonts_test.rs`) are gated on
+    # `#[cfg(target_os = "macos")]`. They would silently vanish from
+    # the Linux `rust` job above — running them here keeps CoreText
+    # behavior (sorting, UTF-8 encoding, "Helvetica is present")
+    # covered on every PR touching `src-tauri/**`. Filtering to
+    # `--test commands_test commands::fonts_test::macos` compiles only
+    # the `commands_test` integration binary and the library; every
+    # other integration test (db_*, search_*, semantic_*, vault_*, …)
+    # is skipped, so this job is dramatically cheaper than the
+    # previous full macOS-only suite.
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Run fonts tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml --test commands_test commands::fonts_test::macos
 
   # Aggregate gate used as the single required status check for branch
   # protection. `frontend` and `rust` are skipped when their paths
@@ -158,7 +192,7 @@ jobs:
   # skipped, and fails on any real failure or cancellation.
   ci-success:
     name: CI success
-    needs: [changes, frontend, rust]
+    needs: [changes, frontend, rust, rust-fonts-macos]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -169,15 +203,17 @@ jobs:
           changes="${{ needs.changes.result }}"
           frontend="${{ needs.frontend.result }}"
           rust="${{ needs.rust.result }}"
-          echo "changes=$changes frontend=$frontend rust=$rust"
+          rust_fonts_macos="${{ needs.rust-fonts-macos.result }}"
+          echo "changes=$changes frontend=$frontend rust=$rust rust_fonts_macos=$rust_fonts_macos"
           if [ "$changes" != "success" ]; then
             echo "::error::changes job did not succeed (result=$changes)"
             exit 1
           fi
-          for name in frontend rust; do
+          for name in frontend rust rust-fonts-macos; do
             case "$name" in
               frontend) result="$frontend" ;;
               rust) result="$rust" ;;
+              rust-fonts-macos) result="$rust_fonts_macos" ;;
             esac
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "::error::$name job did not pass (result=$result)"


### PR DESCRIPTION
## Context

`ci.yml::rust` ran on `macos-latest` because several modules were
gated on `#[cfg(target_os = "macos")]` — Touch ID, Keychain, CoreText
fonts — and a Linux runner would silently skip them. The encrypted-
notes removal (commit b562224) deleted the Touch ID + Keychain stack,
so the comment block listing those modules was out of date. The only
remaining macOS-only surface is `src/commands/fonts.rs` (CoreText
FFI) and its integration tests at `tests/commands/fonts_test.rs`.

## Solution

Split the Rust suite across two jobs. The main `rust` job moves to
`ubuntu-latest` and runs the full `cargo test --manifest-path
src-tauri/Cargo.toml`; on Linux the gated `macos` module inside
`fonts_test.rs` is excluded by the `#[cfg(target_os = "macos")]`
attribute, so the build compiles cleanly (thanks to the existing
`#[cfg(not(target_os = "macos"))]` fallback in `fonts.rs` that returns
`Ok(vec![])`) and the other 200+ Rust tests run unchanged.

A new `rust-fonts-macos` job stays on `macos-latest` and runs only
`cargo test --test commands_test commands::fonts_test::macos`. The
`--test commands_test` selector restricts compilation to the
`commands_test` integration binary plus the library, skipping every
other integration test binary (db_*, search_*, semantic_*, vault_*,
…), so the macOS runner pays for compiling the lib + one test binary
+ 4 test runs instead of the entire suite.

The setup action's `rust-targets` default is `aarch64-apple-darwin`
(needed for the release/nightly macOS bundle builds). The Linux job
overrides this to `""` so rustup doesn't install a cross-compile
target it won't use.

`ci-success` is the single required check for branch protection. It
now lists `rust-fonts-macos` alongside `frontend` and `rust` in
`needs:`, the result echo, and the validation loop, so a failure in
the fonts job blocks merges and a skip (path filter said no
`src-tauri/**` change) is treated as a pass.

## Behavior

Before: every PR that touched `src-tauri/**` spun up a single macOS
runner, ran the full Rust suite (~15-20 min wall clock incl. cache
restore), and validated everything including the 4 fonts tests.
Linux CI minutes were untouched for Rust.

After: the same PR spins up a Linux runner for the bulk of the Rust
suite and a parallel macOS runner that only compiles + runs the
fonts tests. The 4 fonts tests still execute on every PR; the rest
of the suite moves to the cheaper, faster Linux pool. `release.yml`
and `nightly.yml` invoke `ci.yml` via `workflow_call` and inherit
both jobs automatically — release runs still gate on fonts coverage.

A docs-only PR (no `src-tauri/**` change) skips both `rust` and
`rust-fonts-macos`; `ci-success` accepts the double-skip as pass.

## Files

- .github/workflows/ci.yml:129-184: `rust` moved to `ubuntu-latest`,
  comment block rewritten to reflect the post-encrypted-notes state,
  `rust-targets: ""` override added on the setup composite action.
  New `rust-fonts-macos` job added on `macos-latest` running the
  filtered fonts-only invocation.
- .github/workflows/ci.yml:193-220: `ci-success` `needs:` extended
  with `rust-fonts-macos`; aggregation script extended with the new
  job result variable, echo, loop entry, and case branch.