### PR TITLE
feat: Portent POC - types, relationships, lifecycle

### DIFF
--- a/.scratch/portent-support/PRD.md
+++ b/.scratch/portent-support/PRD.md
@@ -1,0 +1,27 @@
+# Portent Spec Support for Koko Brain
+
+## Summary
+
+Implement the Portent knowledge base spec in Koko Brain. Portent defines 8 document types (PORT: Project, Operation, Responsibility, Task; ENTP: Event, Note, Topic, Person), semantic relationships (`belongs_to`, `related_to`), and a 3-stage lifecycle (captured, organized, archived).
+
+## Reference
+
+- Portent spec: https://portent.md
+- Tolaria (reference implementation): https://github.com/refactoringhq/tolaria
+
+## Phases
+
+### Phase 1 - Foundation (type + lifecycle)
+System metadata aliases, `is_a` type field in Rust index, lifecycle flags (organized/archived/favorite), UI actions for lifecycle, archived entry filtering.
+
+### Phase 2 - Relationships
+`belongs_to`/`related_to` fields in Rust index, backlinks panel with relationship context, collection filter extensions for type/relationship/lifecycle fields.
+
+### Phase 3 - Navigation
+Type definition entries (notes with `type: Type`), type-grouped sidebar mode, inbox workflow with explicit organization.
+
+## Non-goals
+
+- Schema validation/enforcement (Portent types are lenses, not schemas)
+- Plugin system changes
+- Migration tooling for existing vaults

--- a/.scratch/portent-support/issues/01-system-metadata-aliases.md
+++ b/.scratch/portent-support/issues/01-system-metadata-aliases.md
@@ -1,0 +1,41 @@
+Status: ready-for-agent
+Phase: 1
+
+# System metadata aliases for frontmatter normalization
+
+## What to build
+
+A shared alias resolution layer that maps alternative frontmatter key names to their canonical forms. Both Rust (vault index) and TypeScript (properties, collections) sides need to recognize multiple spellings of the same semantic key.
+
+Canonical mappings:
+- `type` <- `is_a`, `is a`
+- `belongs_to` <- `belongs to`
+- `related_to` <- `related to`
+- `_organized` <- `organized`
+- `_archived` <- `archived`
+- `_favorite` <- `favorite`
+- `_order` <- `order`
+- `_sort` <- `sort`
+- `_icon` <- `icon`
+- `_sidebar_label` <- `sidebar_label`, `sidebar label`
+- `_color` <- `color`
+- `_template` <- `template`
+- `_view` <- `view`
+- `_visible` <- `visible`
+- `_list_properties_display` <- `list_properties_display`
+
+Reference: Tolaria's `systemMetadata.ts` for the full alias set.
+
+The resolution should happen at parse time so downstream consumers always see canonical keys.
+
+## Acceptance criteria
+
+- [ ] Rust-side alias map defined and used during frontmatter parsing in the vault index
+- [ ] TypeScript-side alias map available as a pure logic utility
+- [ ] Frontmatter with any alias variant normalizes to canonical key in parsed output
+- [ ] Unit tests covering each alias mapping (Rust and TypeScript)
+- [ ] Existing frontmatter parsing behavior unchanged for keys without aliases
+
+## Blocked by
+
+None - can start immediately.

--- a/.scratch/portent-support/issues/01-system-metadata-aliases.md
+++ b/.scratch/portent-support/issues/01-system-metadata-aliases.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 1
 
 # System metadata aliases for frontmatter normalization

--- a/.scratch/portent-support/issues/02-type-field-in-rust-index.md
+++ b/.scratch/portent-support/issues/02-type-field-in-rust-index.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 1
 
 # Add is_a type field to NoteEntryV2 and vault index

--- a/.scratch/portent-support/issues/02-type-field-in-rust-index.md
+++ b/.scratch/portent-support/issues/02-type-field-in-rust-index.md
@@ -1,0 +1,27 @@
+Status: ready-for-agent
+Phase: 1
+
+# Add is_a type field to NoteEntryV2 and vault index
+
+## What to build
+
+Add an `is_a` field to `NoteEntryV2` in the Rust vault index. When a note's frontmatter contains `type` (or any alias from issue 01), extract the value, normalize casing (first letter uppercase, rest preserved), and store it on the entry.
+
+The TypeScript mirror type (`vault-v2.types.ts`) must also gain the field. The `get_all_vault_entries_v2` IPC command already returns entries - the new field flows through automatically via serde.
+
+Notes with `type: Type` (or `is_a: Type`) are Type Definition entries - they define a type rather than being an instance. This distinction matters for issue 09 but should already be parseable here.
+
+## Acceptance criteria
+
+- [ ] `NoteEntryV2` has `is_a: Option<String>` in Rust
+- [ ] TypeScript mirror type has `isA: string | null`
+- [ ] Frontmatter `type: Project` -> `is_a: Some("Project")`
+- [ ] Aliases resolved via system metadata (issue 01)
+- [ ] Casing normalized: `project` -> `Project`, `NOTE` -> `Note`
+- [ ] Notes without a type field -> `is_a: None` / `null`
+- [ ] Rust unit tests for parsing and normalization
+- [ ] Existing vault index behavior unchanged for notes without type field
+
+## Blocked by
+
+- 01-system-metadata-aliases

--- a/.scratch/portent-support/issues/03-lifecycle-flags-in-rust-index.md
+++ b/.scratch/portent-support/issues/03-lifecycle-flags-in-rust-index.md
@@ -1,0 +1,31 @@
+Status: ready-for-agent
+Phase: 1
+
+# Add lifecycle flags (organized/archived/favorite) to vault index
+
+## What to build
+
+Add three boolean fields to `NoteEntryV2`: `organized`, `archived`, `favorite`. Parsed from frontmatter using alias resolution (issue 01). Default to `false` when absent.
+
+These flags represent the Portent lifecycle:
+- `organized: false` + `archived: false` = captured (in inbox)
+- `organized: true` + `archived: false` = organized (active)
+- `archived: true` = archived (inactive, hidden from default views)
+- `favorite` is orthogonal - pins to a favorites section
+
+The TypeScript mirror type must also gain these fields.
+
+## Acceptance criteria
+
+- [ ] `NoteEntryV2` has `organized: bool`, `archived: bool`, `favorite: bool` in Rust
+- [ ] TypeScript mirror type has matching fields
+- [ ] `_organized: true` in frontmatter -> `organized: true`
+- [ ] `_archived: true` in frontmatter -> `archived: true`
+- [ ] Aliases resolved via system metadata (issue 01)
+- [ ] Missing flags default to `false`
+- [ ] Rust unit tests for all flag combinations
+- [ ] IPC commands return the new fields
+
+## Blocked by
+
+- 01-system-metadata-aliases

--- a/.scratch/portent-support/issues/03-lifecycle-flags-in-rust-index.md
+++ b/.scratch/portent-support/issues/03-lifecycle-flags-in-rust-index.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 1
 
 # Add lifecycle flags (organized/archived/favorite) to vault index

--- a/.scratch/portent-support/issues/04-lifecycle-ui-actions.md
+++ b/.scratch/portent-support/issues/04-lifecycle-ui-actions.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 1
 
 # Lifecycle UI actions in Inspector panel

--- a/.scratch/portent-support/issues/04-lifecycle-ui-actions.md
+++ b/.scratch/portent-support/issues/04-lifecycle-ui-actions.md
@@ -1,0 +1,30 @@
+Status: ready-for-agent
+Phase: 1
+
+# Lifecycle UI actions in Inspector panel
+
+## What to build
+
+Add UI controls for toggling lifecycle state on notes. End-to-end: button click -> frontmatter update -> save -> Rust index updated -> UI reflects new state.
+
+Actions needed:
+- "Mark as organized" / "Mark as not organized" toggle in the Inspector panel
+- "Archive" / "Unarchive" action (Inspector panel or context menu)
+- "Favorite" / "Unfavorite" toggle (already may exist for bookmarks - adapt or extend)
+
+Each action writes the canonical frontmatter key (`_organized`, `_archived`, `_favorite`) with the new boolean value. The save triggers `update_note_in_index` which picks up the new flags (from issue 03).
+
+## Acceptance criteria
+
+- [ ] "Organized" toggle visible in Inspector for non-Type notes
+- [ ] Clicking toggle writes `_organized: true/false` to frontmatter and saves
+- [ ] "Archive" action available in Inspector or note context menu
+- [ ] Archive action writes `_archived: true` to frontmatter and saves
+- [ ] "Unarchive" available on archived notes
+- [ ] Vault index reflects new flag values after save
+- [ ] Visual indicator showing current lifecycle state (organized/archived)
+- [ ] Tests for frontmatter mutation logic
+
+## Blocked by
+
+- 03-lifecycle-flags-in-rust-index

--- a/.scratch/portent-support/issues/05-filter-archived-from-default-views.md
+++ b/.scratch/portent-support/issues/05-filter-archived-from-default-views.md
@@ -1,0 +1,30 @@
+Status: ready-for-agent
+Phase: 1
+
+# Filter archived entries from default note list
+
+## What to build
+
+Archived notes (`_archived: true`) should be hidden from the default note list and sidebar. Add an "Archived" filter/view that shows only archived notes, similar to a trash view.
+
+This affects:
+- Main note list: exclude archived by default
+- Sidebar file explorer: option to hide archived
+- Search: include archived in results but visually mark them
+- Quick switcher: include archived but visually distinguish
+
+The filtering should use the `archived` flag from the vault index (issue 03), not re-parse frontmatter.
+
+## Acceptance criteria
+
+- [ ] Default note list excludes notes with `archived: true`
+- [ ] Dedicated "Archived" view/filter shows only archived notes
+- [ ] Archived notes accessible via search (visually distinguished)
+- [ ] Quick switcher includes archived notes (visually distinguished)
+- [ ] Unarchiving a note returns it to default views immediately
+- [ ] Count of archived notes visible somewhere (sidebar badge or filter label)
+- [ ] Tests for filtering logic
+
+## Blocked by
+
+- 03-lifecycle-flags-in-rust-index

--- a/.scratch/portent-support/issues/05-filter-archived-from-default-views.md
+++ b/.scratch/portent-support/issues/05-filter-archived-from-default-views.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 1
 
 # Filter archived entries from default note list

--- a/.scratch/portent-support/issues/06-relationship-fields-in-rust-index.md
+++ b/.scratch/portent-support/issues/06-relationship-fields-in-rust-index.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 2
 
 # Parse belongs_to/related_to and wikilink-bearing fields in Rust index

--- a/.scratch/portent-support/issues/06-relationship-fields-in-rust-index.md
+++ b/.scratch/portent-support/issues/06-relationship-fields-in-rust-index.md
@@ -1,0 +1,32 @@
+Status: ready-for-agent
+Phase: 2
+
+# Parse belongs_to/related_to and wikilink-bearing fields in Rust index
+
+## What to build
+
+Extend the Rust vault index to extract semantic relationship fields from frontmatter. Three categories:
+
+1. **`belongs_to`**: hierarchical ownership (task belongs to project). Frontmatter key `belongs_to` (or alias `belongs to`). Value is a single wikilink string or array of wikilink strings.
+2. **`related_to`**: lateral connections. Same format as `belongs_to`.
+3. **Custom relationships**: any other frontmatter field whose value contains `[[wikilink]]` syntax. Stored as a generic map.
+
+Wikilink extraction from frontmatter values: detect `[[target]]` pattern, store raw target string. Resolution to actual entries happens at read time (TypeScript side), not at index time.
+
+Add corresponding fields to the TypeScript mirror type.
+
+## Acceptance criteria
+
+- [ ] `NoteEntryV2` has `belongs_to: Vec<String>`, `related_to: Vec<String>`, `relationships: HashMap<String, Vec<String>>` in Rust
+- [ ] TypeScript mirror has matching fields
+- [ ] `belongs_to: "[[project]]"` -> `belongs_to: ["project"]`
+- [ ] `belongs_to: ["[[a]]", "[[b]]"]` -> `belongs_to: ["a", "b"]`
+- [ ] Aliases resolved via system metadata
+- [ ] Custom field `mentor: "[[john]]"` -> `relationships: {"mentor": ["john"]}`
+- [ ] Fields without wikilinks not included in relationships map
+- [ ] Rust unit tests for all value formats (string, array, mixed)
+- [ ] Existing outgoing links (body wikilinks) unchanged
+
+## Blocked by
+
+- 01-system-metadata-aliases

--- a/.scratch/portent-support/issues/07-backlinks-with-relationship-context.md
+++ b/.scratch/portent-support/issues/07-backlinks-with-relationship-context.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 2
 
 # Extend backlinks panel with frontmatter relationship context

--- a/.scratch/portent-support/issues/07-backlinks-with-relationship-context.md
+++ b/.scratch/portent-support/issues/07-backlinks-with-relationship-context.md
@@ -1,0 +1,30 @@
+Status: ready-for-agent
+Phase: 2
+
+# Extend backlinks panel with frontmatter relationship context
+
+## What to build
+
+The backlinks panel currently shows notes that link to the current note via body wikilinks. Extend it to also show notes that reference the current note via frontmatter relationships (`belongs_to`, `related_to`, custom fields from issue 06).
+
+Display should indicate the relationship type:
+- "Parent of" (when another note has `belongs_to: "[[current-note]]"`)
+- "Related from" (when another note has `related_to: "[[current-note]]"`)
+- Custom relationship name for generic relationships
+
+This requires a new Rust IPC command or extending `get_backlinks_v2` to include frontmatter relationship sources. The reverse index should track which entries reference which targets via frontmatter fields.
+
+## Acceptance criteria
+
+- [ ] Backlinks panel shows notes referencing current note via `belongs_to`
+- [ ] Backlinks panel shows notes referencing current note via `related_to`
+- [ ] Backlinks panel shows notes referencing current note via custom relationship fields
+- [ ] Each backlink displays its relationship type label
+- [ ] Body-text backlinks still shown (existing behavior preserved)
+- [ ] Visual distinction between body backlinks and relationship backlinks
+- [ ] Rust reverse index tracks frontmatter relationship targets
+- [ ] Tests for reverse index building and querying
+
+## Blocked by
+
+- 06-relationship-fields-in-rust-index

--- a/.scratch/portent-support/issues/08-collection-filter-extensions.md
+++ b/.scratch/portent-support/issues/08-collection-filter-extensions.md
@@ -1,0 +1,34 @@
+Status: ready-for-agent
+Phase: 2
+
+# Add type, relationship, and lifecycle field resolvers to collection filters
+
+## What to build
+
+The collection filter DSL already supports filtering by frontmatter properties. Extend it with first-class support for Portent fields so users can build views like "all Projects", "tasks belonging to X", "unorganized notes".
+
+New filter fields:
+- `type` / `is_a`: filter by document type (`equals`, `not_equals`, `is_empty`)
+- `belongs_to`: filter by ownership target (`contains`, `is_empty`)
+- `related_to`: filter by relationship target (`contains`, `is_empty`)
+- `organized`: boolean filter
+- `archived`: boolean filter
+- `favorite`: boolean filter
+
+These fields should resolve from the indexed entry fields (issues 02, 03, 06), not re-parse frontmatter.
+
+## Acceptance criteria
+
+- [ ] Collection filter recognizes `type` as a filterable field
+- [ ] `{ field: "type", op: "equals", value: "Project" }` filters correctly
+- [ ] `belongs_to` and `related_to` work with `contains` operator
+- [ ] `organized`, `archived`, `favorite` work as boolean filters
+- [ ] Existing property-based filters unchanged
+- [ ] Collection views using new fields render correctly in the UI
+- [ ] Tests for each new field resolver
+
+## Blocked by
+
+- 02-type-field-in-rust-index
+- 03-lifecycle-flags-in-rust-index
+- 06-relationship-fields-in-rust-index

--- a/.scratch/portent-support/issues/08-collection-filter-extensions.md
+++ b/.scratch/portent-support/issues/08-collection-filter-extensions.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 2
 
 # Add type, relationship, and lifecycle field resolvers to collection filters

--- a/.scratch/portent-support/issues/09-type-definition-entry-parser.md
+++ b/.scratch/portent-support/issues/09-type-definition-entry-parser.md
@@ -1,0 +1,52 @@
+Status: ready-for-agent
+Phase: 3
+
+# Type definition entry parser and reactive store
+
+## What to build
+
+Notes with `type: Type` are Type Definitions - they define a document type rather than being an instance of one. Create a new feature module that parses these entries and exposes their metadata reactively.
+
+A Type Definition entry looks like:
+```yaml
+---
+type: Type
+_color: red
+_icon: rocket
+_order: 2
+_sidebar_label: Projects
+_template: "..."
+_sort: title
+_view: all
+_visible: true
+_list_properties_display:
+  - belongs_to
+  - status
+---
+# Project
+
+Projects are time-bound efforts that produce an output.
+```
+
+The module should:
+1. Identify Type Definition entries from vault index (`is_a === "Type"`)
+2. Extract display metadata: icon, color, order, sidebar label, template, sort, view, visible, list properties display
+3. Build a reactive map: type name (from entry title) -> metadata
+4. Rebuild when vault index updates (`vaultIndexVersion` pattern)
+
+New feature: `src/lib/features/type-definitions/`
+
+## Acceptance criteria
+
+- [ ] Feature module with `type-definitions.logic.ts`, `type-definitions.store.svelte.ts`, `type-definitions.service.ts`
+- [ ] Correctly identifies entries with `is_a: "Type"`
+- [ ] Extracts icon, color, order, sidebar label from frontmatter
+- [ ] Reactive store rebuilds on `vaultIndexVersion` change
+- [ ] Provides lookup: `getTypeMetadata("Project")` -> `{ icon, color, order, label }`
+- [ ] Handles vaults with no Type Definition entries (graceful empty state)
+- [ ] Built-in fallback metadata for common types (Project, Person, Event, Topic, Task, Note)
+- [ ] Tests for logic, store getters
+
+## Blocked by
+
+- 02-type-field-in-rust-index

--- a/.scratch/portent-support/issues/09-type-definition-entry-parser.md
+++ b/.scratch/portent-support/issues/09-type-definition-entry-parser.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 3
 
 # Type definition entry parser and reactive store

--- a/.scratch/portent-support/issues/10-type-grouped-sidebar.md
+++ b/.scratch/portent-support/issues/10-type-grouped-sidebar.md
@@ -1,0 +1,59 @@
+Status: ready-for-agent
+Phase: 3
+
+# Type-grouped sidebar mode
+
+## What to build
+
+A new sidebar mode that groups notes by their Portent type instead of filesystem folders. This is the primary navigation mode for Portent-compatible vaults.
+
+Sidebar structure:
+```
+[Search]
+[Filters: All | Inbox | Archived | Favorites]
+---
+[Type sections, ordered by _order then alphabetical]
+  Projects (icon: rocket, color: red)
+    - Launch website
+    - Try padel
+  Responsibilities (icon: target, color: red)
+    - Stay in good shape
+  People (icon: users, color: blue)
+    - Sergio Panagia
+  Topics (icon: tag, color: green)
+    - Padel
+    - Portent
+  Notes (icon: file-text, color: green)
+    - How I Run Tolaria
+---
+[Untyped] (notes without is_a field)
+[Folders] (existing file explorer, collapsed)
+```
+
+Each type section:
+- Header with icon + color + label from Type Definition metadata (issue 09)
+- Collapsible list of notes of that type
+- Click note -> open in editor
+- Note count badge
+- Default sort from Type Definition's `_sort` field
+
+Toggle between type-sidebar and file-explorer via settings or a sidebar mode switcher.
+
+## Acceptance criteria
+
+- [ ] New sidebar component showing notes grouped by type
+- [ ] Type sections use icon, color, label from Type Definition store (issue 09)
+- [ ] Sections sorted by `_order`, then alphabetical
+- [ ] Filter bar: All (default), Inbox (not organized, not archived), Archived, Favorites
+- [ ] "Untyped" section for notes without `is_a`
+- [ ] File explorer still accessible (toggle or tab)
+- [ ] Notes within sections sorted by Type Definition's `_sort` or title
+- [ ] Note count badge per section
+- [ ] Clicking a note opens it in the editor
+- [ ] Sidebar updates reactively when notes are created, deleted, or re-typed
+- [ ] Settings toggle to choose default sidebar mode
+- [ ] Tests for section building logic
+
+## Blocked by
+
+- 09-type-definition-entry-parser

--- a/.scratch/portent-support/issues/10-type-grouped-sidebar.md
+++ b/.scratch/portent-support/issues/10-type-grouped-sidebar.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 3
 
 # Type-grouped sidebar mode

--- a/.scratch/portent-support/issues/11-inbox-workflow.md
+++ b/.scratch/portent-support/issues/11-inbox-workflow.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: done
 Phase: 3
 
 # Inbox workflow with explicit organization setting

--- a/.scratch/portent-support/issues/11-inbox-workflow.md
+++ b/.scratch/portent-support/issues/11-inbox-workflow.md
@@ -1,0 +1,37 @@
+Status: ready-for-agent
+Phase: 3
+
+# Inbox workflow with explicit organization setting
+
+## What to build
+
+An optional "explicit organization" mode where new notes start in an Inbox state until the user marks them as organized. This implements the Portent lifecycle's capture-first philosophy: capture fast, organize later.
+
+When enabled:
+- New notes are created without `_organized` in frontmatter (defaults to `false`)
+- "Inbox" filter in the type-grouped sidebar shows all non-organized, non-archived notes
+- Inbox count badge shows how many notes need organizing
+- "Mark as organized" action (from issue 04) removes the note from Inbox
+- Assigning a `type` to a note could optionally auto-organize it (setting)
+
+When disabled:
+- No Inbox concept, all notes visible in default views
+- `_organized` flag ignored for filtering purposes
+
+Setting: `settings.vault.explicitOrganization: boolean` (default: `false` for backwards compatibility).
+
+## Acceptance criteria
+
+- [ ] New setting `explicitOrganization` in vault settings (default `false`)
+- [ ] When enabled: Inbox filter shows notes with `organized: false` and `archived: false`
+- [ ] When enabled: Inbox count badge in sidebar
+- [ ] When enabled: new notes start unorganized
+- [ ] When disabled: Inbox filter hidden, all notes in default view
+- [ ] "Mark as organized" removes note from Inbox immediately
+- [ ] Setting toggle accessible from settings UI
+- [ ] Tests for inbox filtering logic with setting on/off
+
+## Blocked by
+
+- 04-lifecycle-ui-actions
+- 10-type-grouped-sidebar

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Some features in Kokobrain were inspired by ideas from Obsidian community plugin
 - **Calendar** — inspired by [oz-calendar](https://github.com/ozntel/oz-calendar)
 - **Folder notes** — inspired by [obsidian-folder-notes](https://github.com/LostPaul/obsidian-folder-notes)
 - **Auto open & Pin tab** — inspired by [obsidian-homepage](https://github.com/mirnovov/obsidian-homepage)
+- **Types & Relationships** — inspired by the [Portent](https://portent.md) knowledge base spec (document types, semantic relationships, lifecycle workflow)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Your notes are plain Markdown files stored locally — no cloud, no lock-in, pri
 - **Auto-move** — automatically route notes to folders based on expression rules
 - **Deep links** — open notes and trigger actions from outside the app via `kokobrain://` URLs
 - **Meta-bind** — interactive inline inputs and action buttons that read/write frontmatter
+- **Note types** — declare `type: Project` in frontmatter, browse notes grouped by type in a dedicated sidebar mode
+- **Relationships** — semantic `belongs_to` / `related_to` fields with relationship backlinks in the sidebar
+- **Lifecycle** — organize, archive, and favorite notes with inbox workflow and filtered views
 - **Custom file icons** — 11 icon packs + emoji with color picker
 - **Bookmarks**, **tags**, **backlinks**, **outgoing links**, **properties** panel
 - **Templates**, **quick note** capture, and **1:1 meeting notes**
@@ -110,7 +113,7 @@ src/lib/
   features/             # Always loaded: search, backlinks, tags, properties, tasks, canvas,
                         #   collection, file-history, bookmarks, file-icons, copy-block-link,
                         #   auto-move, command-palette, quick-switcher, folder-notes,
-                        #   outgoing-links, deep-link
+                        #   outgoing-links, deep-link, type-definitions
   plugins/              # Optional: periodic-notes, calendar, templates, quick-note,
                         #   graph-view, terminal, queryjs, word-count, kanban, one-on-one,
                         #   table-of-contents
@@ -133,6 +136,7 @@ src-tauri/src/
 - **[Commit Conventions](docs/COMMITS.md)** — Commit message format and examples
 - **[Live Preview Architecture](docs/LIVE-PREVIEW.md)** — Editor live preview plugin system
 - **[Search Architecture](docs/SEARCH.md)** — Retrieval pipeline, chunking, models, RRF, versioning levers
+- **[Types & Relationships](help/documentation/25-types-and-relationships.md)** — Note types, semantic relationships, lifecycle workflow
 - **[GitHub Workflows](GITHUB-WORKFLOW.md)** — What each CI workflow tests, when it runs, and what it does not cover
 - **[Release Channels](docs/RELEASE-CHANNELS.md)** — Stable vs Nightly channels, version semantics, switching from inside the app
 

--- a/help/documentation/07-sidebar-panels.md
+++ b/help/documentation/07-sidebar-panels.md
@@ -82,6 +82,10 @@ The panel is divided into two sections:
 
 Click any backlink to open that source note.
 
+### Relationship Backlinks
+
+Below the linked and unlinked mention sections, a **Relationships** section shows notes that reference the current note through frontmatter relationship fields (`belongs_to`, `related_to`, or custom wikilink-bearing fields). Each entry shows the source note and the relationship field name. See [Types & Relationships](25-types-and-relationships.md) for details.
+
 ### Why backlinks matter
 
 Backlinks let you discover connections you might not remember. If you link to "Project X" from multiple meeting notes, the backlinks panel on "Project X" shows all those meetings — creating a reverse index of your knowledge. You never have to manually maintain a list of related notes; the backlinks panel builds one for you automatically.

--- a/help/documentation/25-types-and-relationships.md
+++ b/help/documentation/25-types-and-relationships.md
@@ -1,0 +1,199 @@
+# Types, Relationships & Lifecycle
+
+Kokobrain supports structured note types, semantic relationships between notes, and a lifecycle workflow for organizing your knowledge base. These features are inspired by the [Portent](https://portent.md) knowledge base specification.
+
+---
+
+## Note Types
+
+Every note can declare a type via the `type` (or `is_a`) frontmatter field. Types are free-form strings -- you can use any name you want.
+
+```yaml
+---
+type: Project
+---
+```
+
+Built-in type suggestions with default icons and colors:
+
+| Type | Icon | Color |
+|------|------|-------|
+| Project | Rocket | Red |
+| Person | Users | Blue |
+| Event | Calendar | Purple |
+| Topic | Tag | Green |
+| Task | Check Square | Orange |
+| Note | File Text | Gray |
+
+You can use any other type name (e.g. `Recipe`, `Book`, `Meeting`) and it will appear in the type sidebar with default styling.
+
+### Type Definitions
+
+To customize how a type appears in the sidebar, create a **Type Definition note** -- a note whose type is `Type`:
+
+```yaml
+---
+type: Type
+_icon: rocket
+_color: red
+_order: 1
+_sidebar_label: Projects
+_sort: title
+_view: all
+_visible: true
+_template: _system/templates/Project.md
+_list_properties_display:
+  - status
+  - priority
+---
+```
+
+The note's title becomes the type name (e.g., a note titled "Project" with `type: Type` defines the "Project" type).
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `_icon` | Lucide icon name | `file-text` |
+| `_color` | Display color | `gray` |
+| `_order` | Sidebar sort order (lower = higher) | `50` |
+| `_sidebar_label` | Override the section label | `{Name}s` |
+| `_sort` | Sort field for notes | `title` |
+| `_view` | Default view mode | `all` |
+| `_visible` | Whether to show in sidebar | `true` |
+| `_template` | Template for new notes of this type | none |
+| `_list_properties_display` | Properties to show in list views | none |
+
+---
+
+## Type Sidebar
+
+The left sidebar has two modes, toggled by the button in the file explorer header:
+
+- **Files** (default) -- standard file explorer tree
+- **Types** -- notes grouped by their `type` field
+
+In type mode, notes are organized into collapsible sections by type. Each section shows the type icon, label, and note count. Notes without a type appear in an "Untyped" section at the bottom.
+
+### Filters
+
+The type sidebar has four filter tabs:
+
+| Filter | Shows |
+|--------|-------|
+| All | All notes except archived |
+| Inbox | Notes not yet organized (requires Explicit Organization) |
+| Archived | Archived notes only |
+| Favorites | Favorited notes (excluding archived) |
+
+---
+
+## Relationships
+
+Notes can declare semantic relationships to other notes using frontmatter fields with wikilink values.
+
+### Built-in relationship fields
+
+```yaml
+---
+belongs_to: "[[Parent Project]]"
+related_to:
+  - "[[Topic A]]"
+  - "[[Topic B]]"
+---
+```
+
+- **`belongs_to`** -- hierarchical ownership (this note belongs to another)
+- **`related_to`** -- non-hierarchical association
+
+Both fields accept a single wikilink or a list of wikilinks.
+
+### Custom relationship fields
+
+Any frontmatter field whose value contains wikilinks is treated as a relationship. For example:
+
+```yaml
+---
+manager: "[[Alice Smith]]"
+client: "[[Acme Corp]]"
+---
+```
+
+### Relationship Backlinks
+
+The Backlinks panel (right sidebar) includes a **Relationships** section that shows notes referencing the current note through relationship fields. Each entry displays the source note and the field name (e.g., "belongs_to", "manager").
+
+---
+
+## Lifecycle
+
+Notes have three lifecycle states controlled by frontmatter flags:
+
+| State | Flags | Meaning |
+|-------|-------|---------|
+| Inbox | `_organized: false` (or absent) | Newly created, not yet triaged |
+| Organized | `_organized: true` | Deliberately placed in your system |
+| Archived | `_archived: true` | No longer active, hidden from default views |
+
+### Lifecycle Actions
+
+The Properties panel shows lifecycle action buttons below the frontmatter fields:
+
+- **Organize** -- marks a note as organized (moves it out of inbox)
+- **To Inbox** -- moves an organized note back to inbox
+- **Archive** -- hides the note from default views
+- **Unarchive** -- restores an archived note
+- **Favorite** (star icon) -- toggles the favorite flag
+
+### Explicit Organization Mode
+
+By default, notes are treated as organized. Enable **Explicit Organization** in settings to activate the inbox workflow:
+
+- New notes start as unorganized (inbox)
+- The Inbox filter tab appears in the type sidebar with a badge count
+- The Quick Switcher excludes archived notes from results
+
+### Archived Note Filtering
+
+Archived notes are automatically excluded from:
+
+- The default "All" view in the type sidebar
+- The Quick Switcher results
+- The "Favorites" filter
+
+Archived notes remain accessible through the "Archived" filter tab.
+
+---
+
+## Frontmatter Key Aliases
+
+Kokobrain recognizes alternative spellings for system metadata keys:
+
+| Alias | Canonical form |
+|-------|---------------|
+| `is_a`, `is a` | `type` |
+| `belongs to` | `belongs_to` |
+| `related to` | `related_to` |
+| `organized` | `_organized` |
+| `archived` | `_archived` |
+| `favorite` | `_favorite` |
+
+You can use either form in your frontmatter. The app normalizes them internally.
+
+---
+
+## Collection Filters
+
+The Collection feature supports filtering by Portent fields:
+
+- Filter by `type` to show only notes of a specific type
+- Filter by `belongs_to` or `related_to` relationships
+- Filter by lifecycle state (`organized`, `archived`, `favorite`)
+
+See [Collection](12-collection.md) for details on building filtered views.
+
+---
+
+## Next Steps
+
+- [Sidebar Panels](07-sidebar-panels.md) -- Backlinks panel with relationship context
+- [Collection](12-collection.md) -- Build database views filtered by type and relationships
+- [Properties](07-sidebar-panels.md#properties-frontmatter-editor) -- Edit frontmatter fields visually

--- a/help/documentation/README.md
+++ b/help/documentation/README.md
@@ -44,6 +44,7 @@ After that, explore any topic that interests you.
 | 22 | [Auto Move](22-auto-move.md) | Automatically move notes to folders based on expression rules |
 | 23 | [Deep Links](23-deep-links.md) | Open notes and trigger actions from outside the app via `kokobrain://` URLs |
 | 24 | [Meta-Bind](24-meta-bind.md) | Interactive inline inputs and action buttons that read/write frontmatter |
+| 25 | [Types & Relationships](25-types-and-relationships.md) | Note types, semantic relationships, lifecycle workflow, type sidebar |
 
 ## Embedded Local Files (`file://` images)
 

--- a/help/examples/type-definitions-features/README.md
+++ b/help/examples/type-definitions-features/README.md
@@ -1,0 +1,52 @@
+# Type definitions examples
+
+Sample notes demonstrating types, relationships, lifecycle flags, and
+type definitions. Open these in Kokobrain to see the type sidebar,
+relationship backlinks, and lifecycle actions in action.
+
+## What's here
+
+| File | Demonstrates |
+|------|--------------|
+| **Type definitions** | |
+| `_types/Project.md` | Type definition with custom icon, color, order, and template |
+| `_types/Person.md` | Type definition with built-in fallback overrides |
+| `_types/Topic.md` | Type definition with list properties display |
+| **Typed notes** | |
+| `project-kokobrain.md` | Project note with `belongs_to` and `related_to` relationships |
+| `project-website-redesign.md` | Archived project showing lifecycle flags |
+| `person-alice.md` | Person note linked via `manager` relationship from projects |
+| `person-bob.md` | Person note in inbox (not organized) |
+| `topic-rust.md` | Topic note with favorites and multiple backlinks |
+| `topic-svelte.md` | Topic note referenced by projects |
+| `meeting-kickoff.md` | Untyped note with `belongs_to` relationship |
+
+## How types work
+
+1. Notes declare their type via `type: Project` (or `is_a: Project`) in frontmatter.
+2. Type definition notes (`type: Type`) customize how each type appears in the sidebar.
+3. The type sidebar groups notes by type and supports filtering by lifecycle state.
+
+## How relationships work
+
+1. `belongs_to: "[[project-kokobrain]]"` creates a hierarchical link.
+2. `related_to: ["[[topic-rust]]", "[[topic-svelte]]"]` creates associations.
+3. Any frontmatter field with wikilink values creates a relationship.
+4. The Backlinks panel shows a Relationships section with these connections.
+
+## How lifecycle works
+
+1. `_organized: true` marks a note as organized (out of inbox).
+2. `_archived: true` hides it from default views.
+3. `_favorite: true` marks it for the Favorites filter.
+4. The Properties panel shows action buttons to toggle these states.
+
+## Trying it locally
+
+1. Copy this folder into your vault.
+2. Switch to type sidebar mode (click the grid icon in the file explorer header).
+3. Browse Projects, People, and Topics sections.
+4. Open `project-kokobrain.md` and check the Backlinks panel for relationship backlinks.
+5. Enable Explicit Organization in Settings > Types to see the Inbox filter.
+
+See [Types & Relationships](../../documentation/25-types-and-relationships.md) for the full guide.

--- a/help/examples/type-definitions-features/_types/Person.md
+++ b/help/examples/type-definitions-features/_types/Person.md
@@ -1,0 +1,13 @@
+---
+type: Type
+_icon: users
+_color: blue
+_order: 2
+_sidebar_label: People
+_visible: true
+---
+
+# Person
+
+A person you work with, manage, or collaborate on projects with.
+Link people to projects via `manager`, `assignee`, or custom relationship fields.

--- a/help/examples/type-definitions-features/_types/Project.md
+++ b/help/examples/type-definitions-features/_types/Project.md
@@ -1,0 +1,18 @@
+---
+type: Type
+_icon: rocket
+_color: red
+_order: 1
+_sidebar_label: Projects
+_sort: title
+_visible: true
+_template: _system/templates/Project.md
+_list_properties_display:
+  - status
+  - priority
+---
+
+# Project
+
+A project is a body of work with a clear goal, timeline, and deliverables.
+Projects can have sub-tasks, related topics, and assigned people.

--- a/help/examples/type-definitions-features/_types/Topic.md
+++ b/help/examples/type-definitions-features/_types/Topic.md
@@ -1,0 +1,15 @@
+---
+type: Type
+_icon: tag
+_color: green
+_order: 4
+_sidebar_label: Topics
+_visible: true
+_list_properties_display:
+  - tags
+---
+
+# Topic
+
+A topic is a subject area or domain of knowledge.
+Use topics to group related notes and projects thematically.

--- a/help/examples/type-definitions-features/meeting-kickoff.md
+++ b/help/examples/type-definitions-features/meeting-kickoff.md
@@ -1,0 +1,24 @@
+---
+belongs_to: "[[project-kokobrain]]"
+date: 2026-01-15
+attendees:
+  - "[[person-alice]]"
+  - "[[person-bob]]"
+tags:
+  - meeting
+_organized: true
+---
+
+# Kickoff Meeting
+
+Initial planning meeting for the Kokobrain type system.
+
+## Decisions
+- Use frontmatter `type` field (not folder-based typing)
+- Relationship fields use wikilink values
+- Lifecycle managed by `_organized` / `_archived` / `_favorite` flags
+- Type definitions are notes with `type: Type`
+
+## Action items
+- [ ] Alice: draft type definition schema
+- [ ] Bob: prototype type sidebar component

--- a/help/examples/type-definitions-features/person-alice.md
+++ b/help/examples/type-definitions-features/person-alice.md
@@ -1,0 +1,18 @@
+---
+type: Person
+role: Engineering Manager
+team: Platform
+tags:
+  - engineering
+  - leadership
+_organized: true
+---
+
+# Alice Smith
+
+Engineering manager for the Platform team. Leads Kokobrain and related projects.
+
+## Notes
+- Prefers async communication over meetings
+- Available for 1:1s on Tuesdays and Thursdays
+- Deep expertise in Rust and systems programming

--- a/help/examples/type-definitions-features/person-bob.md
+++ b/help/examples/type-definitions-features/person-bob.md
@@ -1,0 +1,16 @@
+---
+type: Person
+role: Frontend Engineer
+team: Platform
+related_to: "[[topic-svelte]]"
+tags:
+  - engineering
+  - frontend
+---
+
+# Bob Chen
+
+Frontend engineer on the Platform team. New hire, still in onboarding.
+
+This note is not yet organized (no `_organized` flag), so it appears
+in the Inbox when Explicit Organization is enabled.

--- a/help/examples/type-definitions-features/project-kokobrain.md
+++ b/help/examples/type-definitions-features/project-kokobrain.md
@@ -1,0 +1,29 @@
+---
+type: Project
+status: active
+priority: high
+manager: "[[person-alice]]"
+related_to:
+  - "[[topic-rust]]"
+  - "[[topic-svelte]]"
+tags:
+  - desktop
+  - open-source
+_organized: true
+_favorite: true
+---
+
+# Kokobrain
+
+Desktop note-taking app built with Svelte 5 and Tauri 2.
+
+## Goals
+- Full offline operation with local-first data
+- Markdown files as the source of truth
+- Fast search with FTS5 and semantic embeddings
+
+## Tasks
+- [x] Core editor with CodeMirror 6
+- [x] Wikilink resolution and backlinks
+- [x] Type system and relationship tracking
+- [ ] Mobile companion app

--- a/help/examples/type-definitions-features/project-website-redesign.md
+++ b/help/examples/type-definitions-features/project-website-redesign.md
@@ -1,0 +1,20 @@
+---
+type: Project
+status: completed
+priority: low
+manager: "[[person-alice]]"
+belongs_to: "[[project-kokobrain]]"
+tags:
+  - marketing
+  - design
+_organized: true
+_archived: true
+---
+
+# Website Redesign
+
+Landing page redesign for the Kokobrain project site.
+
+## Outcome
+Shipped in Q1 2026. New design improved conversion by 40%.
+This project is now archived.

--- a/help/examples/type-definitions-features/topic-rust.md
+++ b/help/examples/type-definitions-features/topic-rust.md
@@ -1,0 +1,21 @@
+---
+type: Topic
+tags:
+  - programming
+  - systems
+_organized: true
+_favorite: true
+---
+
+# Rust
+
+Systems programming language focused on safety, speed, and concurrency.
+
+## Why Rust for Kokobrain
+- Memory safety without garbage collection
+- Excellent FFI with Tauri for desktop apps
+- Strong type system catches bugs at compile time
+
+## Resources
+- The Rust Book: https://doc.rust-lang.org/book/
+- Rust by Example: https://doc.rust-lang.org/rust-by-example/

--- a/help/examples/type-definitions-features/topic-svelte.md
+++ b/help/examples/type-definitions-features/topic-svelte.md
@@ -1,0 +1,23 @@
+---
+type: Topic
+tags:
+  - programming
+  - frontend
+  - javascript
+_organized: true
+---
+
+# Svelte
+
+Compiler-based UI framework. Svelte 5 introduces runes for fine-grained reactivity.
+
+## Why Svelte for Kokobrain
+- Compiled output is small and fast
+- Runes ($state, $derived, $effect) replace stores
+- First-class TypeScript support
+- SvelteKit for routing and SSR (used for dev server)
+
+## Key patterns
+- `$effect` + `untrack()` for service calls
+- Getter-based stores instead of `$derived` in tests
+- PaneForge for resizable panels

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -661,6 +661,19 @@ fn project_note_record(entry: &NoteEntry) -> NoteRecord {
 		Some(idx) if idx > 0 => path[..idx].to_string(),
 		_ => String::new(),
 	};
+	let mut properties = entry.frontmatter.clone();
+	if let Some(ref is_a) = entry.is_a {
+		properties.insert("type".to_string(), serde_json::Value::String(is_a.clone()));
+	}
+	properties.insert("organized".to_string(), serde_json::Value::Bool(entry.organized));
+	properties.insert("archived".to_string(), serde_json::Value::Bool(entry.archived));
+	properties.insert("favorite".to_string(), serde_json::Value::Bool(entry.favorite));
+	if !entry.belongs_to.is_empty() {
+		properties.insert("belongs_to".to_string(), serde_json::json!(entry.belongs_to));
+	}
+	if !entry.related_to.is_empty() {
+		properties.insert("related_to".to_string(), serde_json::json!(entry.related_to));
+	}
 	NoteRecord {
 		path: path.clone(),
 		name,
@@ -670,7 +683,7 @@ fn project_note_record(entry: &NoteEntry) -> NoteRecord {
 		mtime: entry.modified_at.saturating_mul(1000),
 		ctime: entry.created_at.saturating_mul(1000),
 		size: entry.size,
-		properties: entry.frontmatter.clone(),
+		properties,
 	}
 }
 

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -1,6 +1,6 @@
 use crate::utils::fs as vault_fs;
 use crate::utils::logger::debug_log;
-use crate::vault::entry::{NoteEntry, NoteRecord, OutgoingLink, OutgoingUnlinkedMention};
+use crate::vault::entry::{NoteEntry, NoteRecord, OutgoingLink, OutgoingUnlinkedMention, RelationshipBacklink};
 use crate::vault::index::{match_unlinked_mentions, UpdateResult, VaultIndex};
 use crate::vault::parsing::{extract_tasks_from_section, toggle_task_in_content};
 use crate::vault::task::{display_name, FileTaskGroup, TagAggregate, Task, ToggleTaskResult};
@@ -313,6 +313,20 @@ pub fn get_backlinks_v2(
 		.read()
 		.map_err(|e| format!("VaultIndex lock poisoned: {}", e))?;
 	Ok(idx.lookup_backlinks(&path))
+}
+
+/// Returns notes that reference `path` via frontmatter relationship fields
+/// (`belongs_to`, `related_to`, or custom wikilink-bearing fields).
+#[tauri::command]
+pub fn get_relationship_backlinks_v2(
+	path: String,
+	state: tauri::State<'_, VaultIndexState>,
+) -> Result<Vec<RelationshipBacklink>, String> {
+	let _trace = CmdTrace::new("get_relationship_backlinks_v2");
+	let idx = state
+		.read()
+		.map_err(|e| format!("VaultIndex lock poisoned: {}", e))?;
+	Ok(idx.lookup_relationship_backlinks(&path))
 }
 
 /// Returns the outgoing wikilinks of `path`, each resolved against the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,7 @@ pub fn run() {
             commands::vault::scan_vault,
             commands::vault::scan_vault_v2,
             commands::vault::get_backlinks_v2,
+            commands::vault::get_relationship_backlinks_v2,
             commands::vault::get_outgoing_links_v2,
             commands::vault::get_outgoing_unlinked_mentions_v2,
             commands::vault::get_all_vault_entries_v2,

--- a/src-tauri/src/vault/aliases.rs
+++ b/src-tauri/src/vault/aliases.rs
@@ -1,0 +1,76 @@
+//! Frontmatter key alias resolution.
+//!
+//! Maps alternative spellings of system metadata keys to their canonical form.
+//! Called at parse time so downstream consumers always see canonical keys.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+static ALIAS_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+	let mut m = HashMap::new();
+	m.insert("is_a", "type");
+	m.insert("is a", "type");
+	m.insert("belongs to", "belongs_to");
+	m.insert("related to", "related_to");
+	m.insert("organized", "_organized");
+	m.insert("archived", "_archived");
+	m.insert("favorite", "_favorite");
+	m.insert("order", "_order");
+	m.insert("sort", "_sort");
+	m.insert("icon", "_icon");
+	m.insert("sidebar_label", "_sidebar_label");
+	m.insert("sidebar label", "_sidebar_label");
+	m.insert("color", "_color");
+	m.insert("template", "_template");
+	m.insert("view", "_view");
+	m.insert("visible", "_visible");
+	m.insert("list_properties_display", "_list_properties_display");
+	m
+});
+
+/// Returns the canonical key name if the input matches a known alias,
+/// otherwise returns the input unchanged.
+pub fn canonicalize_key(key: &str) -> &str {
+	ALIAS_MAP.get(key).copied().unwrap_or(key)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn known_aliases_resolve() {
+		assert_eq!(canonicalize_key("is_a"), "type");
+		assert_eq!(canonicalize_key("is a"), "type");
+		assert_eq!(canonicalize_key("belongs to"), "belongs_to");
+		assert_eq!(canonicalize_key("related to"), "related_to");
+		assert_eq!(canonicalize_key("organized"), "_organized");
+		assert_eq!(canonicalize_key("archived"), "_archived");
+		assert_eq!(canonicalize_key("favorite"), "_favorite");
+		assert_eq!(canonicalize_key("order"), "_order");
+		assert_eq!(canonicalize_key("sort"), "_sort");
+		assert_eq!(canonicalize_key("icon"), "_icon");
+		assert_eq!(canonicalize_key("sidebar_label"), "_sidebar_label");
+		assert_eq!(canonicalize_key("sidebar label"), "_sidebar_label");
+		assert_eq!(canonicalize_key("color"), "_color");
+		assert_eq!(canonicalize_key("template"), "_template");
+		assert_eq!(canonicalize_key("view"), "_view");
+		assert_eq!(canonicalize_key("visible"), "_visible");
+		assert_eq!(canonicalize_key("list_properties_display"), "_list_properties_display");
+	}
+
+	#[test]
+	fn canonical_keys_pass_through() {
+		assert_eq!(canonicalize_key("type"), "type");
+		assert_eq!(canonicalize_key("belongs_to"), "belongs_to");
+		assert_eq!(canonicalize_key("_organized"), "_organized");
+		assert_eq!(canonicalize_key("_icon"), "_icon");
+	}
+
+	#[test]
+	fn unknown_keys_pass_through() {
+		assert_eq!(canonicalize_key("title"), "title");
+		assert_eq!(canonicalize_key("tags"), "tags");
+		assert_eq!(canonicalize_key("custom_field"), "custom_field");
+	}
+}

--- a/src-tauri/src/vault/entry.rs
+++ b/src-tauri/src/vault/entry.rs
@@ -175,6 +175,14 @@ pub struct NoteEntry {
 	pub archived: bool,
 	/// Lifecycle flag: note is pinned as a favorite. Default `false`.
 	pub favorite: bool,
+	/// Hierarchical ownership targets from `belongs_to` frontmatter field.
+	/// Wikilink targets extracted from the value (e.g. `[[project]]` -> `"project"`).
+	pub belongs_to: Vec<String>,
+	/// Lateral relationship targets from `related_to` frontmatter field.
+	pub related_to: Vec<String>,
+	/// Generic relationships: frontmatter fields whose values contain wikilinks.
+	/// Key is the field name, value is the list of wikilink targets.
+	pub relationships: BTreeMap<String, Vec<String>>,
 }
 
 impl NoteEntry {
@@ -210,6 +218,9 @@ impl NoteEntry {
 		let organized = extract_bool_flag(&frontmatter, "_organized");
 		let archived = extract_bool_flag(&frontmatter, "_archived");
 		let favorite = extract_bool_flag(&frontmatter, "_favorite");
+		let belongs_to = extract_wikilink_targets(&frontmatter, "belongs_to");
+		let related_to = extract_wikilink_targets(&frontmatter, "related_to");
+		let relationships = extract_all_relationships(&frontmatter);
 		let body = strip_frontmatter(content);
 		let word_count = compute_word_count(body);
 		let snippet = compute_snippet(body);
@@ -229,6 +240,9 @@ impl NoteEntry {
 			organized,
 			archived,
 			favorite,
+			belongs_to,
+			related_to,
+			relationships,
 		}
 	}
 }
@@ -314,4 +328,84 @@ fn extract_bool_flag(frontmatter: &BTreeMap<String, JsonValue>, key: &str) -> bo
 		.get(key)
 		.and_then(|v| v.as_bool())
 		.unwrap_or(false)
+}
+
+/// Extracts wikilink targets from a frontmatter field value.
+/// Supports string values (`"[[target]]"`) and arrays (`["[[a]]", "[[b]]"]`).
+fn extract_wikilink_targets(frontmatter: &BTreeMap<String, JsonValue>, key: &str) -> Vec<String> {
+	let Some(val) = frontmatter.get(key) else {
+		return Vec::new();
+	};
+	match val {
+		JsonValue::String(s) => extract_wikilinks_from_str(s),
+		JsonValue::Array(arr) => {
+			arr.iter()
+				.filter_map(|v| v.as_str())
+				.flat_map(extract_wikilinks_from_str)
+				.collect()
+		}
+		_ => Vec::new(),
+	}
+}
+
+/// Extracts all frontmatter fields (excluding known system keys) that contain
+/// wikilinks in their values. Returns a map of field name -> wikilink targets.
+fn extract_all_relationships(frontmatter: &BTreeMap<String, JsonValue>) -> BTreeMap<String, Vec<String>> {
+	const SYSTEM_KEYS: &[&str] = &[
+		"type", "belongs_to", "related_to",
+		"_organized", "_archived", "_favorite",
+		"_order", "_sort", "_icon", "_sidebar_label",
+		"_color", "_template", "_view", "_visible",
+		"_list_properties_display",
+		"tags", "aliases",
+	];
+	let mut result = BTreeMap::new();
+	for (key, val) in frontmatter {
+		if SYSTEM_KEYS.contains(&key.as_str()) {
+			continue;
+		}
+		let targets = match val {
+			JsonValue::String(s) => extract_wikilinks_from_str(s),
+			JsonValue::Array(arr) => {
+				arr.iter()
+					.filter_map(|v| v.as_str())
+					.flat_map(extract_wikilinks_from_str)
+					.collect()
+			}
+			_ => Vec::new(),
+		};
+		if !targets.is_empty() {
+			result.insert(key.clone(), targets);
+		}
+	}
+	result
+}
+
+/// Extracts wikilink targets (`[[target]]`) from a string value.
+fn extract_wikilinks_from_str(s: &str) -> Vec<String> {
+	let mut targets = Vec::new();
+	let bytes = s.as_bytes();
+	let mut i = 0;
+	while i + 1 < bytes.len() {
+		if bytes[i] == b'[' && bytes[i + 1] == b'[' {
+			i += 2;
+			let start = i;
+			while i + 1 < bytes.len() && !(bytes[i] == b']' && bytes[i + 1] == b']') {
+				i += 1;
+			}
+			if i + 1 < bytes.len() {
+				let raw = &s[start..i];
+				let target = raw.split('|').next().unwrap_or(raw);
+				let target = target.split('#').next().unwrap_or(target);
+				let trimmed = target.trim();
+				if !trimmed.is_empty() {
+					targets.push(trimmed.to_string());
+				}
+				i += 2;
+			}
+		} else {
+			i += 1;
+		}
+	}
+	targets
 }

--- a/src-tauri/src/vault/entry.rs
+++ b/src-tauri/src/vault/entry.rs
@@ -114,6 +114,19 @@ pub struct OutgoingUnlinkedMention {
 	pub count: usize,
 }
 
+/// A backlink from a frontmatter relationship field.
+/// Carries the source entry info plus the relationship type label.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelationshipBacklink {
+	/// Absolute path of the note that references the target.
+	pub source_path: String,
+	/// Title of the source note.
+	pub source_name: String,
+	/// Relationship type (e.g. "belongs_to", "related_to", or custom field name).
+	pub relationship_type: String,
+}
+
 /// Canonical per-note metadata used by the Rust `VaultIndex`.
 ///
 /// Constructed by Phase 1.5's `scan_vault_v2` and Phase 2's

--- a/src-tauri/src/vault/entry.rs
+++ b/src-tauri/src/vault/entry.rs
@@ -165,6 +165,10 @@ pub struct NoteEntry {
 	/// `vault::parsing::extract_tasks` at construction time. Empty Vec when
 	/// the note has no tasks.
 	pub tasks: Vec<Task>,
+	/// Document type from the `type` frontmatter key (after alias resolution).
+	/// Casing normalized: first letter uppercase, rest preserved.
+	/// `None` when the note has no type field.
+	pub is_a: Option<String>,
 }
 
 impl NoteEntry {
@@ -196,6 +200,7 @@ impl NoteEntry {
 		let outgoing_links = extract_outgoing_links(content);
 		let tags = extract_tags_strict(content);
 		let tasks = extract_tasks(content);
+		let is_a = extract_is_a(&frontmatter);
 		let body = strip_frontmatter(content);
 		let word_count = compute_word_count(body);
 		let snippet = compute_snippet(body);
@@ -211,6 +216,7 @@ impl NoteEntry {
 			word_count,
 			snippet,
 			tasks,
+			is_a,
 		}
 	}
 }
@@ -266,4 +272,25 @@ fn compute_snippet(body: &str) -> String {
 		snippet.truncate(end);
 	}
 	snippet
+}
+
+/// Extracts the `type` value from parsed frontmatter and normalizes casing
+/// (first letter uppercase, rest preserved). Returns `None` when absent or
+/// not a string.
+fn extract_is_a(frontmatter: &BTreeMap<String, JsonValue>) -> Option<String> {
+	let val = frontmatter.get("type")?;
+	let s = val.as_str()?;
+	if s.is_empty() {
+		return None;
+	}
+	Some(normalize_type_casing(s))
+}
+
+/// First letter uppercase, rest preserved.
+fn normalize_type_casing(s: &str) -> String {
+	let mut chars = s.chars();
+	match chars.next() {
+		None => String::new(),
+		Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+	}
 }

--- a/src-tauri/src/vault/entry.rs
+++ b/src-tauri/src/vault/entry.rs
@@ -169,6 +169,12 @@ pub struct NoteEntry {
 	/// Casing normalized: first letter uppercase, rest preserved.
 	/// `None` when the note has no type field.
 	pub is_a: Option<String>,
+	/// Lifecycle flag: note has been explicitly organized. Default `false`.
+	pub organized: bool,
+	/// Lifecycle flag: note is archived (hidden from default views). Default `false`.
+	pub archived: bool,
+	/// Lifecycle flag: note is pinned as a favorite. Default `false`.
+	pub favorite: bool,
 }
 
 impl NoteEntry {
@@ -201,6 +207,9 @@ impl NoteEntry {
 		let tags = extract_tags_strict(content);
 		let tasks = extract_tasks(content);
 		let is_a = extract_is_a(&frontmatter);
+		let organized = extract_bool_flag(&frontmatter, "_organized");
+		let archived = extract_bool_flag(&frontmatter, "_archived");
+		let favorite = extract_bool_flag(&frontmatter, "_favorite");
 		let body = strip_frontmatter(content);
 		let word_count = compute_word_count(body);
 		let snippet = compute_snippet(body);
@@ -217,6 +226,9 @@ impl NoteEntry {
 			snippet,
 			tasks,
 			is_a,
+			organized,
+			archived,
+			favorite,
 		}
 	}
 }
@@ -293,4 +305,13 @@ fn normalize_type_casing(s: &str) -> String {
 		None => String::new(),
 		Some(c) => c.to_uppercase().to_string() + chars.as_str(),
 	}
+}
+
+/// Extracts a boolean flag from frontmatter. Returns `false` when absent
+/// or not a boolean value.
+fn extract_bool_flag(frontmatter: &BTreeMap<String, JsonValue>, key: &str) -> bool {
+	frontmatter
+		.get(key)
+		.and_then(|v| v.as_bool())
+		.unwrap_or(false)
 }

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -606,7 +606,8 @@ impl VaultIndex {
 		if let Some(resolved) = self.by_path.get(&target.to_lowercase()) {
 			return resolved == expected_path;
 		}
-		target.to_lowercase() == *expected_name_lower
+		let basename = note_name_from_target(target).to_lowercase();
+		basename == *expected_name_lower
 	}
 
 	/// Returns the outgoing wikilinks of the entry at `path`, each with its

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -10,7 +10,7 @@
 //! See ADR 0025 (`docs/adr/0025-rust-vault-index.md`) for the migration
 //! plan and how this replaces the per-feature TS stores.
 
-use crate::vault::entry::{NoteEntry, OutgoingLink, OutgoingUnlinkedMention};
+use crate::vault::entry::{NoteEntry, OutgoingLink, OutgoingUnlinkedMention, RelationshipBacklink};
 use crate::vault::parsing::{find_plain_text_mention_positions, strip_non_body_content};
 use crate::vault::task::{display_name, FileTaskGroup, TagAggregate, Task};
 use serde::{Deserialize, Serialize};
@@ -544,6 +544,69 @@ impl VaultIndex {
 		};
 		sources.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
 		sources
+	}
+
+	/// Returns notes that reference the target note via frontmatter relationship
+	/// fields (`belongs_to`, `related_to`, or custom fields in `relationships`).
+	/// Resolves wikilink targets against `by_path` to match on absolute paths.
+	pub fn lookup_relationship_backlinks(&self, target_path: &str) -> Vec<RelationshipBacklink> {
+		let target_name = target_path
+			.rsplit('/')
+			.next()
+			.unwrap_or(target_path)
+			.strip_suffix(".md")
+			.or_else(|| target_path.rsplit('/').next().unwrap_or(target_path).strip_suffix(".markdown"))
+			.unwrap_or(target_path.rsplit('/').next().unwrap_or(target_path));
+		let target_lower = target_name.to_lowercase();
+
+		let mut results = Vec::new();
+		for entry in self.entries.values() {
+			if entry.path == target_path {
+				continue;
+			}
+			for t in &entry.belongs_to {
+				if self.resolves_to(t, target_path, &target_lower) {
+					results.push(RelationshipBacklink {
+						source_path: entry.path.clone(),
+						source_name: entry.title.clone(),
+						relationship_type: "belongs_to".to_string(),
+					});
+					break;
+				}
+			}
+			for t in &entry.related_to {
+				if self.resolves_to(t, target_path, &target_lower) {
+					results.push(RelationshipBacklink {
+						source_path: entry.path.clone(),
+						source_name: entry.title.clone(),
+						relationship_type: "related_to".to_string(),
+					});
+					break;
+				}
+			}
+			for (field_name, targets) in &entry.relationships {
+				for t in targets {
+					if self.resolves_to(t, target_path, &target_lower) {
+						results.push(RelationshipBacklink {
+							source_path: entry.path.clone(),
+							source_name: entry.title.clone(),
+							relationship_type: field_name.clone(),
+						});
+						break;
+					}
+				}
+			}
+		}
+		results.sort_by(|a, b| a.source_name.to_lowercase().cmp(&b.source_name.to_lowercase()));
+		results
+	}
+
+	/// Checks if a wikilink target resolves to the given path.
+	fn resolves_to(&self, target: &str, expected_path: &str, expected_name_lower: &str) -> bool {
+		if let Some(resolved) = self.by_path.get(&target.to_lowercase()) {
+			return resolved == expected_path;
+		}
+		target.to_lowercase() == *expected_name_lower
 	}
 
 	/// Returns the outgoing wikilinks of the entry at `path`, each with its

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -10,6 +10,7 @@
 //! plan; the per-task breakdown lives in
 //! `tasks/todo/performance-architecture-refactor.md`.
 
+pub mod aliases;
 pub mod entry;
 pub mod index;
 pub mod parsing;

--- a/src-tauri/src/vault/parsing.rs
+++ b/src-tauri/src/vault/parsing.rs
@@ -12,6 +12,7 @@
 //! the markers (`[`, `]`, `|`, `#`, backtick, `<`, `>`) are all ASCII and
 //! UTF-8 multi-byte sequences never collide with them.
 
+use crate::vault::aliases::canonicalize_key;
 use crate::vault::entry::WikiLink;
 use crate::vault::task::{RecurrenceRule, Task, TaskMetadata, TaskPriority, TaskStatus};
 use regex::Regex;
@@ -501,7 +502,7 @@ fn parse_yaml_lines(lines: &[&str]) -> BTreeMap<String, JsonValue> {
 			continue;
 		};
 
-		let key = key.to_string();
+		let key = canonicalize_key(key).to_string();
 		let value_trimmed = raw_value.trim();
 
 		if value_trimmed.is_empty() {

--- a/src-tauri/tests/vault_entry_test.rs
+++ b/src-tauri/tests/vault_entry_test.rs
@@ -97,6 +97,9 @@ fn note_entry_serializes_with_camel_case_keys() {
 		snippet: "This is the first paragraph.".to_string(),
 		tasks: Vec::new(),
 		is_a: None,
+		organized: false,
+		archived: false,
+		favorite: false,
 	};
 
 	let value = serde_json::to_value(&entry).unwrap();
@@ -116,6 +119,9 @@ fn note_entry_serializes_with_camel_case_keys() {
 		"snippet",
 		"tasks",
 		"isA",
+		"organized",
+		"archived",
+		"favorite",
 	];
 	for key in expected_keys {
 		assert!(obj.contains_key(key), "missing key: {}", key);
@@ -181,6 +187,9 @@ fn note_entry_round_trips_through_json() {
 		snippet: "snip".to_string(),
 		tasks: Vec::new(),
 		is_a: None,
+		organized: false,
+		archived: false,
+		favorite: false,
 	};
 
 	let json = serde_json::to_string(&original).unwrap();
@@ -385,4 +394,63 @@ fn from_content_is_a_none_for_non_string_type() {
 	let content = "---\ntype: [a, b]\n---\n";
 	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
 	assert_eq!(entry.is_a, None);
+}
+
+// --- Lifecycle flags (Portent issue 03) --------------------------------------
+
+#[test]
+fn from_content_lifecycle_flags_default_false() {
+	let content = "---\ntitle: Hello\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(!entry.organized);
+	assert!(!entry.archived);
+	assert!(!entry.favorite);
+}
+
+#[test]
+fn from_content_organized_flag_from_canonical_key() {
+	let content = "---\n_organized: true\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.organized);
+}
+
+#[test]
+fn from_content_archived_flag_from_canonical_key() {
+	let content = "---\n_archived: true\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.archived);
+}
+
+#[test]
+fn from_content_favorite_flag_from_canonical_key() {
+	let content = "---\n_favorite: true\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.favorite);
+}
+
+#[test]
+fn from_content_lifecycle_flags_via_aliases() {
+	let content = "---\norganized: true\narchived: true\nfavorite: true\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.organized);
+	assert!(entry.archived);
+	assert!(entry.favorite);
+}
+
+#[test]
+fn from_content_lifecycle_flags_false_when_explicit() {
+	let content = "---\n_organized: false\n_archived: false\n_favorite: false\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(!entry.organized);
+	assert!(!entry.archived);
+	assert!(!entry.favorite);
+}
+
+#[test]
+fn from_content_lifecycle_flags_ignore_non_boolean() {
+	let content = "---\n_organized: yes\n_archived: 1\n_favorite: on\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(!entry.organized);
+	assert!(!entry.archived);
+	assert!(!entry.favorite);
 }

--- a/src-tauri/tests/vault_entry_test.rs
+++ b/src-tauri/tests/vault_entry_test.rs
@@ -100,6 +100,9 @@ fn note_entry_serializes_with_camel_case_keys() {
 		organized: false,
 		archived: false,
 		favorite: false,
+		belongs_to: Vec::new(),
+		related_to: Vec::new(),
+		relationships: BTreeMap::new(),
 	};
 
 	let value = serde_json::to_value(&entry).unwrap();
@@ -122,6 +125,9 @@ fn note_entry_serializes_with_camel_case_keys() {
 		"organized",
 		"archived",
 		"favorite",
+		"belongsTo",
+		"relatedTo",
+		"relationships",
 	];
 	for key in expected_keys {
 		assert!(obj.contains_key(key), "missing key: {}", key);
@@ -190,6 +196,9 @@ fn note_entry_round_trips_through_json() {
 		organized: false,
 		archived: false,
 		favorite: false,
+		belongs_to: Vec::new(),
+		related_to: Vec::new(),
+		relationships: BTreeMap::new(),
 	};
 
 	let json = serde_json::to_string(&original).unwrap();
@@ -453,4 +462,73 @@ fn from_content_lifecycle_flags_ignore_non_boolean() {
 	assert!(!entry.organized);
 	assert!(!entry.archived);
 	assert!(!entry.favorite);
+}
+
+// --- Relationship fields (Portent issue 06) ----------------------------------
+
+#[test]
+fn from_content_belongs_to_single_wikilink() {
+	let content = "---\nbelongs_to: \"[[project]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.belongs_to, vec!["project"]);
+}
+
+#[test]
+fn from_content_belongs_to_array_of_wikilinks() {
+	let content = "---\nbelongs_to: [\"[[a]]\", \"[[b]]\"]\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.belongs_to, vec!["a", "b"]);
+}
+
+#[test]
+fn from_content_belongs_to_via_alias() {
+	let content = "---\nbelongs to: \"[[project]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.belongs_to, vec!["project"]);
+}
+
+#[test]
+fn from_content_related_to_single_wikilink() {
+	let content = "---\nrelated_to: \"[[maps]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.related_to, vec!["maps"]);
+}
+
+#[test]
+fn from_content_relationships_empty_when_no_wikilinks() {
+	let content = "---\ntitle: Hello\nstatus: draft\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.relationships.is_empty());
+}
+
+#[test]
+fn from_content_relationships_custom_field_with_wikilink() {
+	let content = "---\nmentor: \"[[john]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.relationships.get("mentor"), Some(&vec!["john".to_string()]));
+}
+
+#[test]
+fn from_content_relationships_excludes_system_keys() {
+	let content = "---\ntype: Project\ntags: [work]\nmentor: \"[[john]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(!entry.relationships.contains_key("type"));
+	assert!(!entry.relationships.contains_key("tags"));
+	assert!(entry.relationships.contains_key("mentor"));
+}
+
+#[test]
+fn from_content_wikilink_strips_alias_and_heading() {
+	let content = "---\nbelongs_to: \"[[project|My Project]]\"\nrelated_to: \"[[note#section]]\"\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.belongs_to, vec!["project"]);
+	assert_eq!(entry.related_to, vec!["note"]);
+}
+
+#[test]
+fn from_content_belongs_to_empty_when_absent() {
+	let content = "---\ntitle: No rels\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert!(entry.belongs_to.is_empty());
+	assert!(entry.related_to.is_empty());
 }

--- a/src-tauri/tests/vault_entry_test.rs
+++ b/src-tauri/tests/vault_entry_test.rs
@@ -96,6 +96,7 @@ fn note_entry_serializes_with_camel_case_keys() {
 		word_count: 215,
 		snippet: "This is the first paragraph.".to_string(),
 		tasks: Vec::new(),
+		is_a: None,
 	};
 
 	let value = serde_json::to_value(&entry).unwrap();
@@ -114,6 +115,7 @@ fn note_entry_serializes_with_camel_case_keys() {
 		"wordCount",
 		"snippet",
 		"tasks",
+		"isA",
 	];
 	for key in expected_keys {
 		assert!(obj.contains_key(key), "missing key: {}", key);
@@ -178,6 +180,7 @@ fn note_entry_round_trips_through_json() {
 		word_count: 10,
 		snippet: "snip".to_string(),
 		tasks: Vec::new(),
+		is_a: None,
 	};
 
 	let json = serde_json::to_string(&original).unwrap();
@@ -331,4 +334,55 @@ fn from_content_full_document_populates_all_fields() {
 	assert!(entry.snippet.starts_with("# Heading"));
 	assert!(entry.snippet.contains("[[Other Note]]"));
 	assert!(entry.snippet.contains("More content below"));
+}
+
+// --- is_a extraction (Portent issue 02) --------------------------------------
+
+#[test]
+fn from_content_extracts_is_a_from_type_field() {
+	let content = "---\ntype: Project\ntitle: Launch\n---\nBody";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, Some("Project".to_string()));
+}
+
+#[test]
+fn from_content_normalizes_is_a_casing_lowercase() {
+	let content = "---\ntype: project\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, Some("Project".to_string()));
+}
+
+#[test]
+fn from_content_normalizes_is_a_casing_allcaps() {
+	let content = "---\ntype: NOTE\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, Some("NOTE".to_string()));
+}
+
+#[test]
+fn from_content_is_a_none_when_no_type_field() {
+	let content = "---\ntitle: Hello\n---\nBody";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, None);
+}
+
+#[test]
+fn from_content_is_a_via_alias_is_a() {
+	let content = "---\nis_a: Person\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, Some("Person".to_string()));
+}
+
+#[test]
+fn from_content_is_a_none_for_empty_type_value() {
+	let content = "---\ntype:\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, None);
+}
+
+#[test]
+fn from_content_is_a_none_for_non_string_type() {
+	let content = "---\ntype: [a, b]\n---\n";
+	let entry = NoteEntry::from_content("/n.md".into(), content, 0);
+	assert_eq!(entry.is_a, None);
 }

--- a/src-tauri/tests/vault_index_test.rs
+++ b/src-tauri/tests/vault_index_test.rs
@@ -5,7 +5,7 @@
 
 use kokobrain_lib::vault::entry::{NoteEntry, WikiLink};
 use kokobrain_lib::vault::index::{UpdateResult, VaultIndex};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Builds a minimal `NoteEntry` with the given path and outgoing-link
 /// targets. Title is derived; everything else is left at defaults.
@@ -1284,7 +1284,6 @@ fn remove_entry_rebuilds_backlinks_for_promoted_surviving_sibling() {
 // ============================================================================
 
 use serde_json::json;
-use std::collections::BTreeMap;
 
 /// Builds a minimal `NoteEntry` carrying frontmatter properties.
 fn entry_with_props(path: &str, props: &[(&str, serde_json::Value)]) -> NoteEntry {
@@ -1885,4 +1884,83 @@ fn audit_finding_11_many_concurrent_writers_against_growing_index() {
 			);
 		}
 	}
+}
+
+// --- Relationship backlinks (Portent issue 07) -------------------------------
+
+#[test]
+fn lookup_relationship_backlinks_finds_belongs_to() {
+	let mut idx = VaultIndex::default();
+	let task = NoteEntry {
+		path: "/v/task.md".to_string(),
+		title: "task".to_string(),
+		belongs_to: vec!["project".to_string()],
+		..Default::default()
+	};
+	let project = entry_with_links("/v/project.md", &[]);
+	idx.build(vec![task, project]);
+
+	let results = idx.lookup_relationship_backlinks("/v/project.md");
+	assert_eq!(results.len(), 1);
+	assert_eq!(results[0].source_path, "/v/task.md");
+	assert_eq!(results[0].relationship_type, "belongs_to");
+}
+
+#[test]
+fn lookup_relationship_backlinks_finds_related_to() {
+	let mut idx = VaultIndex::default();
+	let note = NoteEntry {
+		path: "/v/note.md".to_string(),
+		title: "note".to_string(),
+		related_to: vec!["topic".to_string()],
+		..Default::default()
+	};
+	let topic = entry_with_links("/v/topic.md", &[]);
+	idx.build(vec![note, topic]);
+
+	let results = idx.lookup_relationship_backlinks("/v/topic.md");
+	assert_eq!(results.len(), 1);
+	assert_eq!(results[0].relationship_type, "related_to");
+}
+
+#[test]
+fn lookup_relationship_backlinks_finds_custom_field() {
+	let mut idx = VaultIndex::default();
+	let mut rels = BTreeMap::new();
+	rels.insert("mentor".to_string(), vec!["john".to_string()]);
+	let note = NoteEntry {
+		path: "/v/note.md".to_string(),
+		title: "note".to_string(),
+		relationships: rels,
+		..Default::default()
+	};
+	let john = entry_with_links("/v/john.md", &[]);
+	idx.build(vec![note, john]);
+
+	let results = idx.lookup_relationship_backlinks("/v/john.md");
+	assert_eq!(results.len(), 1);
+	assert_eq!(results[0].relationship_type, "mentor");
+}
+
+#[test]
+fn lookup_relationship_backlinks_empty_when_no_refs() {
+	let mut idx = VaultIndex::default();
+	idx.build(vec![
+		entry_with_links("/v/a.md", &[]),
+		entry_with_links("/v/b.md", &[]),
+	]);
+	assert!(idx.lookup_relationship_backlinks("/v/a.md").is_empty());
+}
+
+#[test]
+fn lookup_relationship_backlinks_does_not_include_self() {
+	let mut idx = VaultIndex::default();
+	let note = NoteEntry {
+		path: "/v/self.md".to_string(),
+		title: "self".to_string(),
+		belongs_to: vec!["self".to_string()],
+		..Default::default()
+	};
+	idx.build(vec![note]);
+	assert!(idx.lookup_relationship_backlinks("/v/self.md").is_empty());
 }

--- a/src-tauri/tests/vault_parsing_test.rs
+++ b/src-tauri/tests/vault_parsing_test.rs
@@ -973,3 +973,62 @@ fn find_plain_text_mention_still_finds_match_before_lowercase_byte_shift() {
 	let positions = find_plain_text_mention_positions(content, &stripped_lower, "Note A");
 	assert_eq!(positions, vec![0]);
 }
+
+// --- Frontmatter alias normalization -----------------------------------------
+
+#[test]
+fn parse_frontmatter_normalizes_is_a_to_type() {
+	let content = "---\nis_a: person\ntitle: Bob\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("type"), Some(&json!("person")));
+	assert!(fm.get("is_a").is_none());
+}
+
+#[test]
+fn parse_frontmatter_normalizes_space_aliases() {
+	let content = "---\nis a: place\nbelongs to: geography\nrelated to: maps\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("type"), Some(&json!("place")));
+	assert_eq!(fm.get("belongs_to"), Some(&json!("geography")));
+	assert_eq!(fm.get("related_to"), Some(&json!("maps")));
+}
+
+#[test]
+fn parse_frontmatter_normalizes_system_underscore_keys() {
+	let content = "---\nicon: rocket\nfavorite: true\norder: 5\ncolor: red\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("_icon"), Some(&json!("rocket")));
+	assert_eq!(fm.get("_favorite"), Some(&json!(true)));
+	assert_eq!(fm.get("_order"), Some(&json!(5)));
+	assert_eq!(fm.get("_color"), Some(&json!("red")));
+	assert!(fm.get("icon").is_none());
+}
+
+#[test]
+fn parse_frontmatter_normalizes_sidebar_label_variants() {
+	let content = "---\nsidebar_label: Notes\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("_sidebar_label"), Some(&json!("Notes")));
+	assert!(fm.get("sidebar_label").is_none());
+
+	let content2 = "---\nsidebar label: Docs\n---\n";
+	let fm2 = parse_frontmatter(content2);
+	assert_eq!(fm2.get("_sidebar_label"), Some(&json!("Docs")));
+}
+
+#[test]
+fn parse_frontmatter_leaves_unknown_keys_unchanged() {
+	let content = "---\ntitle: Hello\ntags: [a, b]\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("title"), Some(&json!("Hello")));
+	assert_eq!(fm.get("tags"), Some(&json!(["a", "b"])));
+}
+
+#[test]
+fn parse_frontmatter_leaves_canonical_keys_unchanged() {
+	let content = "---\n_icon: star\ntype: note\n_organized: true\n---\n";
+	let fm = parse_frontmatter(content);
+	assert_eq!(fm.get("_icon"), Some(&json!("star")));
+	assert_eq!(fm.get("type"), Some(&json!("note")));
+	assert_eq!(fm.get("_organized"), Some(&json!(true)));
+}

--- a/src/lib/core/file-explorer/FileExplorerHeader.svelte
+++ b/src/lib/core/file-explorer/FileExplorerHeader.svelte
@@ -33,9 +33,9 @@
 	}
 </script>
 
-<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
-	<div class="flex items-center gap-0.5">
-		<SidebarModeToggle />
+<div class="flex items-center h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
+	<SidebarModeToggle />
+	<div class="flex items-center gap-0.5 ml-auto">
 		<DailyNoteButton />
 
 		<Tooltip.Root>

--- a/src/lib/core/file-explorer/FileExplorerHeader.svelte
+++ b/src/lib/core/file-explorer/FileExplorerHeader.svelte
@@ -33,9 +33,8 @@
 	}
 </script>
 
-<div class="flex items-center h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
-	<SidebarModeToggle />
-	<div class="flex items-center gap-0.5 ml-auto">
+<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
+	<div class="flex items-center gap-0.5">
 		<DailyNoteButton />
 
 		<Tooltip.Root>
@@ -131,5 +130,7 @@
 				</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
+
+		<SidebarModeToggle />
 	</div>
 </div>

--- a/src/lib/core/file-explorer/FileExplorerHeader.svelte
+++ b/src/lib/core/file-explorer/FileExplorerHeader.svelte
@@ -12,6 +12,7 @@
 	import { changeSortOption } from '$lib/core/filesystem/fs.service';
 	import type { SortOption } from '$lib/core/filesystem/fs.types';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
+	import SidebarModeToggle from '$lib/features/type-definitions/SidebarModeToggle.svelte';
 
 	/** Props passed from the parent FileExplorer component */
 	interface Props {
@@ -34,6 +35,7 @@
 
 <div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
 	<div class="flex items-center gap-0.5">
+		<SidebarModeToggle />
 		<DailyNoteButton />
 
 		<Tooltip.Root>

--- a/src/lib/core/layout/AppShell.svelte
+++ b/src/lib/core/layout/AppShell.svelte
@@ -8,6 +8,7 @@
 	import * as Resizable from '$lib/components/ui/resizable';
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
 	import FileExplorer from '$lib/core/file-explorer/FileExplorer.svelte';
+	import TypeSidebar from '$lib/features/type-definitions/TypeSidebar.svelte';
 	import EditorView from '$lib/core/markdown-editor/EditorView.svelte';
 	import BacklinksPanel from '$lib/features/backlinks/BacklinksPanel.svelte';
 	import OutgoingLinksPanel from '$lib/features/outgoing-links/OutgoingLinksPanel.svelte';
@@ -79,6 +80,8 @@
 					>
 						{#if searchStore.isOpen}
 							<SearchPanel />
+						{:else if settingsStore.layout.sidebarMode === 'types'}
+							<TypeSidebar />
 						{:else}
 							<FileExplorer />
 						{/if}

--- a/src/lib/core/layout/tauri-listeners.service.ts
+++ b/src/lib/core/layout/tauri-listeners.service.ts
@@ -5,6 +5,8 @@ import { settingsDialogStore } from '$lib/core/settings/settings-dialog.store.sv
 import { saveAllDirtyTabs } from '$lib/core/editor/editor.service';
 import { refreshDailyNoteIfDateChanged } from '$lib/plugins/periodic-notes/periodic-notes.service';
 import { vaultStore } from '$lib/core/vault/vault.store.svelte';
+import { refreshArchivedPaths } from '$lib/features/properties/lifecycle-filter.service';
+import { refreshTypeDefinitions } from '$lib/features/type-definitions/type-definitions.service';
 import type { UpdateResultV2 } from '$lib/types/vault-v2.types';
 
 /**
@@ -79,6 +81,8 @@ export function registerVaultIndexUpdatedListener(): () => void {
 	let unlisten: (() => void) | undefined;
 	listen<UpdateResultV2>('vault-index-updated', (event) => {
 		vaultStore.bumpVaultIndexVersion(event.payload.version);
+		refreshArchivedPaths().catch(() => {});
+		refreshTypeDefinitions().catch(() => {});
 	}).then((fn) => {
 		if (cancelled) fn();
 		else unlisten = fn;

--- a/src/lib/core/layout/tauri-listeners.service.ts
+++ b/src/lib/core/layout/tauri-listeners.service.ts
@@ -81,8 +81,8 @@ export function registerVaultIndexUpdatedListener(): () => void {
 	let unlisten: (() => void) | undefined;
 	listen<UpdateResultV2>('vault-index-updated', (event) => {
 		vaultStore.bumpVaultIndexVersion(event.payload.version);
-		refreshArchivedPaths().catch(() => {});
-		refreshTypeDefinitions().catch(() => {});
+		refreshArchivedPaths().catch((err) => { console.error('refreshArchivedPaths failed:', err); });
+		refreshTypeDefinitions().catch((err) => { console.error('refreshTypeDefinitions failed:', err); });
 	}).then((fn) => {
 		if (cancelled) fn();
 		else unlisten = fn;

--- a/src/lib/core/layout/tauri-listeners.service.ts
+++ b/src/lib/core/layout/tauri-listeners.service.ts
@@ -84,6 +84,7 @@ export function registerVaultIndexUpdatedListener(): () => void {
 	listen<UpdateResultV2>('vault-index-updated', (event) => {
 		vaultStore.bumpVaultIndexVersion(event.payload.version);
 		invoke<NoteEntryV2[]>('get_all_vault_entries_v2').then((entries) => {
+			if (cancelled) return;
 			refreshArchivedPaths(entries);
 			refreshTypeDefinitions(entries);
 			typeDefinitionsStore.setEntries(entries);

--- a/src/lib/core/layout/tauri-listeners.service.ts
+++ b/src/lib/core/layout/tauri-listeners.service.ts
@@ -1,4 +1,5 @@
 import { listen } from '@tauri-apps/api/event';
+import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { ask } from '@tauri-apps/plugin-dialog';
 import { settingsDialogStore } from '$lib/core/settings/settings-dialog.store.svelte';
@@ -7,7 +8,8 @@ import { refreshDailyNoteIfDateChanged } from '$lib/plugins/periodic-notes/perio
 import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 import { refreshArchivedPaths } from '$lib/features/properties/lifecycle-filter.service';
 import { refreshTypeDefinitions } from '$lib/features/type-definitions/type-definitions.service';
-import type { UpdateResultV2 } from '$lib/types/vault-v2.types';
+import { typeDefinitionsStore } from '$lib/features/type-definitions/type-definitions.store.svelte';
+import type { NoteEntryV2, UpdateResultV2 } from '$lib/types/vault-v2.types';
 
 /**
  * Registers a listener for the native macOS menu "Settings" event.
@@ -81,8 +83,11 @@ export function registerVaultIndexUpdatedListener(): () => void {
 	let unlisten: (() => void) | undefined;
 	listen<UpdateResultV2>('vault-index-updated', (event) => {
 		vaultStore.bumpVaultIndexVersion(event.payload.version);
-		refreshArchivedPaths().catch((err) => { console.error('refreshArchivedPaths failed:', err); });
-		refreshTypeDefinitions().catch((err) => { console.error('refreshTypeDefinitions failed:', err); });
+		invoke<NoteEntryV2[]>('get_all_vault_entries_v2').then((entries) => {
+			refreshArchivedPaths(entries);
+			refreshTypeDefinitions(entries);
+			typeDefinitionsStore.setEntries(entries);
+		}).catch((err) => { console.error('get_all_vault_entries_v2 failed:', err); });
 	}).then((fn) => {
 		if (cancelled) fn();
 		else unlisten = fn;

--- a/src/lib/core/settings/SettingsDialog.svelte
+++ b/src/lib/core/settings/SettingsDialog.svelte
@@ -23,6 +23,7 @@
 	import TroubleshootingSection from './sections/TroubleshootingSection.svelte';
 	import UpdateSection from './sections/UpdateSection.svelte';
 	import QueryjsSection from './sections/QueryjsSection.svelte';
+	import TypesSection from './sections/TypesSection.svelte';
 	import PaletteIcon from '@lucide/svelte/icons/palette';
 	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
 	import PencilLineIcon from '@lucide/svelte/icons/pencil-line';
@@ -39,6 +40,7 @@
 	import BugIcon from '@lucide/svelte/icons/bug';
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import Code2Icon from '@lucide/svelte/icons/code-2';
+	import LayoutGridIcon from '@lucide/svelte/icons/layout-grid';
 	import type { SettingsSection } from './settings.types';
 	import type { Component } from 'svelte';
 
@@ -59,6 +61,7 @@
 		troubleshooting: BugIcon,
 		update: DownloadIcon,
 		queryjs: Code2Icon,
+		types: LayoutGridIcon,
 	};
 
 	const debouncedSave = debounce(() => {
@@ -206,6 +209,8 @@
 					<TrashSection />
 				{:else if settingsDialogStore.activeSection === 'todoist'}
 					<TodoistSection onchange={debouncedSave} />
+				{:else if settingsDialogStore.activeSection === 'types'}
+					<TypesSection onchange={debouncedSave} />
 				{:else if settingsDialogStore.activeSection === 'troubleshooting'}
 					<TroubleshootingSection onchange={debouncedSave} />
 				{:else if settingsDialogStore.activeSection === 'update'}

--- a/src/lib/core/settings/sections/TypesSection.svelte
+++ b/src/lib/core/settings/sections/TypesSection.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { Switch } from '$lib/components/ui/switch';
+	import { settingsStore } from '../settings.store.svelte';
+	import SettingItem from './SettingItem.svelte';
+
+	let { onchange }: { onchange: () => void } = $props();
+</script>
+
+<div class="flex flex-col gap-2">
+	<h2 class="mb-4 text-lg font-semibold">Types & Lifecycle</h2>
+
+	<SettingItem
+		label="Explicit organization"
+		description="New notes start unorganized and appear in the Inbox. Disable to treat all notes as organized by default."
+	>
+		<Switch
+			checked={settingsStore.explicitOrganization}
+			onCheckedChange={(v) => {
+				settingsStore.setSettings({ ...settingsStore.settings, explicitOrganization: v });
+				onchange();
+			}}
+		/>
+	</SettingItem>
+</div>

--- a/src/lib/core/settings/sections/TypesSection.svelte
+++ b/src/lib/core/settings/sections/TypesSection.svelte
@@ -21,4 +21,19 @@
 			}}
 		/>
 	</SettingItem>
+
+	<h3 class="mt-6 mb-2 text-sm font-medium text-muted-foreground">Type sidebar</h3>
+
+	<SettingItem
+		label="Show untyped notes"
+		description="Show notes without a type in an 'Untyped' section at the bottom of the type sidebar."
+	>
+		<Switch
+			checked={settingsStore.showUntypedNotes}
+			onCheckedChange={(v) => {
+				settingsStore.setSettings({ ...settingsStore.settings, showUntypedNotes: v });
+				onchange();
+			}}
+		/>
+	</SettingItem>
 </div>

--- a/src/lib/core/settings/settings.logic.ts
+++ b/src/lib/core/settings/settings.logic.ts
@@ -84,6 +84,7 @@ export const SETTINGS_SECTION_GROUPS: readonly SettingsSectionGroup[] = [
 			{ id: 'quick-note', label: 'Quick Note' },
 			{ id: 'one-on-one', label: '1:1 Notes' },
 			{ id: 'templates', label: 'Templates' },
+			{ id: 'types', label: 'Types' },
 		],
 	},
 	{

--- a/src/lib/core/settings/settings.service.ts
+++ b/src/lib/core/settings/settings.service.ts
@@ -151,6 +151,7 @@ export async function loadSettings(vaultPath: string): Promise<void> {
 				autoCheck: parsed.updates?.autoCheck ?? DEFAULT_SETTINGS.updates.autoCheck,
 				lastCheckedAt: parsed.updates?.lastCheckedAt ?? DEFAULT_SETTINGS.updates.lastCheckedAt,
 			},
+			explicitOrganization: parsed.explicitOrganization ?? DEFAULT_SETTINGS.explicitOrganization,
 		};
 		settingsStore.setSettings(merged);
 		await saveSettings(vaultPath);

--- a/src/lib/core/settings/settings.service.ts
+++ b/src/lib/core/settings/settings.service.ts
@@ -152,6 +152,7 @@ export async function loadSettings(vaultPath: string): Promise<void> {
 				lastCheckedAt: parsed.updates?.lastCheckedAt ?? DEFAULT_SETTINGS.updates.lastCheckedAt,
 			},
 			explicitOrganization: parsed.explicitOrganization ?? DEFAULT_SETTINGS.explicitOrganization,
+			showUntypedNotes: parsed.showUntypedNotes ?? DEFAULT_SETTINGS.showUntypedNotes,
 		};
 		settingsStore.setSettings(merged);
 		await saveSettings(vaultPath);

--- a/src/lib/core/settings/settings.store.svelte.ts
+++ b/src/lib/core/settings/settings.store.svelte.ts
@@ -119,6 +119,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 		lastCheckedAt: null,
 	},
 	explicitOrganization: false,
+	showUntypedNotes: false,
 };
 
 let settings = $state<AppSettings>(structuredClone(DEFAULT_SETTINGS));
@@ -150,6 +151,7 @@ export const settingsStore = {
 	get queryjs() { return settings.queryjs; },
 	get updates() { return settings.updates; },
 	get explicitOrganization() { return settings.explicitOrganization; },
+	get showUntypedNotes() { return settings.showUntypedNotes; },
 
 	/** Replaces the entire settings object (used on load) */
 	setSettings(value: AppSettings) {

--- a/src/lib/core/settings/settings.store.svelte.ts
+++ b/src/lib/core/settings/settings.store.svelte.ts
@@ -149,6 +149,7 @@ export const settingsStore = {
 	get tagColors() { return settings.tagColors; },
 	get queryjs() { return settings.queryjs; },
 	get updates() { return settings.updates; },
+	get explicitOrganization() { return settings.explicitOrganization; },
 
 	/** Replaces the entire settings object (used on load) */
 	setSettings(value: AppSettings) {

--- a/src/lib/core/settings/settings.store.svelte.ts
+++ b/src/lib/core/settings/settings.store.svelte.ts
@@ -44,6 +44,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 		templatePath: '_system/templates/One on One.md',
 	},
 	layout: {
+		sidebarMode: 'files',
 		rightSidebarVisible: false,
 		calendarVisible: true,
 		propertiesVisible: true,

--- a/src/lib/core/settings/settings.store.svelte.ts
+++ b/src/lib/core/settings/settings.store.svelte.ts
@@ -117,6 +117,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 		autoCheck: false,
 		lastCheckedAt: null,
 	},
+	explicitOrganization: false,
 };
 
 let settings = $state<AppSettings>(structuredClone(DEFAULT_SETTINGS));

--- a/src/lib/core/settings/settings.types.ts
+++ b/src/lib/core/settings/settings.types.ts
@@ -298,4 +298,6 @@ export interface AppSettings {
 	updates: UpdateSettings;
 	/** Whether new notes start unorganized and require explicit organization (Portent inbox workflow) */
 	explicitOrganization: boolean;
+	/** Whether to show notes without a type in the type sidebar */
+	showUntypedNotes: boolean;
 }

--- a/src/lib/core/settings/settings.types.ts
+++ b/src/lib/core/settings/settings.types.ts
@@ -291,4 +291,6 @@ export interface AppSettings {
 	queryjs: QueryjsSettings;
 	/** In-app auto-updater configuration (channel selection, …) */
 	updates: UpdateSettings;
+	/** Whether new notes start unorganized and require explicit organization (Portent inbox workflow) */
+	explicitOrganization: boolean;
 }

--- a/src/lib/core/settings/settings.types.ts
+++ b/src/lib/core/settings/settings.types.ts
@@ -43,7 +43,12 @@ export interface PeriodicNotesUpdate {
 }
 
 /** Configuration for layout visibility preferences */
+/** Left sidebar mode: file explorer (default) or type-grouped view (Portent) */
+export type SidebarMode = 'files' | 'types';
+
 export interface LayoutSettings {
+	/** Left sidebar mode: file explorer or type-grouped */
+	sidebarMode: SidebarMode;
 	/** Whether the right sidebar (Properties, Backlinks, Tags, etc.) is visible */
 	rightSidebarVisible: boolean;
 	/** Whether the calendar panel is shown in the right sidebar */

--- a/src/lib/core/settings/settings.types.ts
+++ b/src/lib/core/settings/settings.types.ts
@@ -249,7 +249,7 @@ export interface UpdateSettings {
 }
 
 /** Sidebar navigation sections in the settings dialog */
-export type SettingsSection = 'appearance' | 'sidebar' | 'editor' | 'periodic-notes' | 'quick-note' | 'one-on-one' | 'templates' | 'terminal' | 'search' | 'file-history' | 'auto-move' | 'trash' | 'todoist' | 'queryjs' | 'troubleshooting' | 'update';
+export type SettingsSection = 'appearance' | 'sidebar' | 'editor' | 'periodic-notes' | 'quick-note' | 'one-on-one' | 'templates' | 'terminal' | 'search' | 'file-history' | 'auto-move' | 'trash' | 'todoist' | 'queryjs' | 'types' | 'troubleshooting' | 'update';
 
 /** Top-level settings object persisted as `.kokobrain/settings.json` inside the vault */
 export interface AppSettings {

--- a/src/lib/features/backlinks/BacklinksPanel.svelte
+++ b/src/lib/features/backlinks/BacklinksPanel.svelte
@@ -2,17 +2,20 @@
 	import { untrack } from 'svelte';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import Link from 'lucide-svelte/icons/link';
+	import GitBranch from 'lucide-svelte/icons/git-branch';
 	import Type from 'lucide-svelte/icons/type';
 	import { Separator } from '$lib/components/ui/separator';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import { editorStore } from '$lib/core/editor/editor.store.svelte';
 	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 	import { backlinksStore } from './backlinks.store.svelte';
-	import { computeUnlinkedMentionsForFile, fetchBacklinksV2 } from './backlinks.service';
+	import { computeUnlinkedMentionsForFile, fetchBacklinksV2, fetchRelationshipBacklinks } from './backlinks.service';
+	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { debounce } from '$lib/utils/debounce';
 	import LinkItem from './LinkItem.svelte';
 
 	let linkedOpen = $state(true);
+	let relationshipsOpen = $state(true);
 	let unlinkedOpen = $state(true);
 
 	// 150 ms coalesce window matches +layout.svelte's tab-switch debounce.
@@ -23,6 +26,7 @@
 	// the service this collapses 5 burst opens into 1 fetch per panel.
 	const refetchBacklinks = debounce((path: string) => {
 		fetchBacklinksV2(path).catch(() => { /* fetchBacklinksV2 already logs */ });
+		fetchRelationshipBacklinks(path).catch(() => { /* already logs */ });
 	}, 150);
 
 	const recomputeUnlinked = debounce((path: string) => {
@@ -85,6 +89,30 @@
 					</div>
 				</Collapsible.Content>
 			</Collapsible.Root>
+
+			{#if backlinksStore.relationshipBacklinks.length > 0}
+				<Collapsible.Root bind:open={relationshipsOpen} class="mt-2">
+					<Collapsible.Trigger class="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 font-medium hover:bg-accent transition-colors cursor-pointer">
+						<ChevronRight class="size-3.5 shrink-0 transition-transform {relationshipsOpen ? 'rotate-90' : ''}" />
+						<GitBranch class="size-3.5 shrink-0 text-muted-foreground" />
+						<span>Relationships</span>
+						<span class="ml-auto text-muted-foreground">{backlinksStore.relationshipBacklinks.length}</span>
+					</Collapsible.Trigger>
+					<Collapsible.Content>
+						<div class="pl-2 mt-1 space-y-0.5">
+							{#each backlinksStore.relationshipBacklinks as rel (rel.sourcePath + rel.relationshipType)}
+								<button
+									class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm hover:bg-accent transition-colors text-left cursor-pointer"
+									onclick={() => openFileInEditor(rel.sourcePath)}
+								>
+									<span class="truncate">{rel.sourceName}</span>
+									<span class="ml-auto text-xs text-muted-foreground shrink-0">{rel.relationshipType.replace('_', ' ')}</span>
+								</button>
+							{/each}
+						</div>
+					</Collapsible.Content>
+				</Collapsible.Root>
+			{/if}
 
 			<Collapsible.Root bind:open={unlinkedOpen} class="mt-2">
 				<Collapsible.Trigger class="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 font-medium hover:bg-accent transition-colors cursor-pointer">

--- a/src/lib/features/backlinks/backlinks.service.ts
+++ b/src/lib/features/backlinks/backlinks.service.ts
@@ -5,7 +5,7 @@ import { editorStore } from '$lib/core/editor/editor.store.svelte';
 import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 import { backlinksStore } from './backlinks.store.svelte';
 import { noteEntryV2ToBacklinkEntry } from './backlinks.logic';
-import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import type { NoteEntryV2, RelationshipBacklinkV2 } from '$lib/types/vault-v2.types';
 
 /**
  * Returns true when the IPC result for `fetchedPath` is still relevant
@@ -127,6 +127,22 @@ async function fetchBacklinksV2Inner(path: string): Promise<void> {
 	}
 }
 export const fetchBacklinksV2 = dedupeInflight(fetchBacklinksV2Inner, (path: string) => path);
+
+/**
+ * Fetches relationship backlinks for a file from the Rust `VaultIndex`.
+ * These are notes that reference the target via frontmatter fields
+ * (`belongs_to`, `related_to`, or custom wikilink-bearing fields).
+ */
+async function fetchRelationshipBacklinksInner(path: string): Promise<void> {
+	try {
+		const entries = await invoke<RelationshipBacklinkV2[]>('get_relationship_backlinks_v2', { path });
+		if (!isStillCurrentPath(path)) return;
+		backlinksStore.setRelationshipBacklinks(entries);
+	} catch (err) {
+		errorLog('BACKLINKS', 'fetchRelationshipBacklinks failed:', err);
+	}
+}
+export const fetchRelationshipBacklinks = dedupeInflight(fetchRelationshipBacklinksInner, (path: string) => path);
 
 /**
  * Computes unlinked mentions on demand by invoking the Rust

--- a/src/lib/features/backlinks/backlinks.store.svelte.ts
+++ b/src/lib/features/backlinks/backlinks.store.svelte.ts
@@ -1,13 +1,16 @@
 import type { BacklinkEntry } from './backlinks.types';
+import type { RelationshipBacklinkV2 } from '$lib/types/vault-v2.types';
 
 let linkedMentions = $state<BacklinkEntry[]>([]);
 let unlinkedMentions = $state<BacklinkEntry[]>([]);
+let relationshipBacklinks = $state<RelationshipBacklinkV2[]>([]);
 /** When true, unlinked mentions are stale and need recomputation */
 let unlinkedDirty = $state(false);
 
 export const backlinksStore = {
 	get linkedMentions() { return linkedMentions; },
 	get unlinkedMentions() { return unlinkedMentions; },
+	get relationshipBacklinks() { return relationshipBacklinks; },
 	get unlinkedDirty() { return unlinkedDirty; },
 
 	setLinkedMentions(entries: BacklinkEntry[]) { linkedMentions = entries; },
@@ -15,12 +18,14 @@ export const backlinksStore = {
 		unlinkedMentions = entries;
 		unlinkedDirty = false;
 	},
+	setRelationshipBacklinks(entries: RelationshipBacklinkV2[]) { relationshipBacklinks = entries; },
 	/** Marks unlinked mentions as stale without recomputing them */
 	markUnlinkedDirty() { unlinkedDirty = true; },
 
 	reset() {
 		linkedMentions = [];
 		unlinkedMentions = [];
+		relationshipBacklinks = [];
 		unlinkedDirty = false;
 	},
 };

--- a/src/lib/features/properties/LifecycleActions.svelte
+++ b/src/lib/features/properties/LifecycleActions.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import Archive from 'lucide-svelte/icons/archive';
+	import ArchiveRestore from 'lucide-svelte/icons/archive-restore';
+	import FolderCheck from 'lucide-svelte/icons/folder-check';
+	import Inbox from 'lucide-svelte/icons/inbox';
+	import Star from 'lucide-svelte/icons/star';
+	import { propertiesStore } from './properties.store.svelte';
+	import { getLifecycleState, isFavorite } from './lifecycle.logic';
+	import { setOrganized, setArchived, setFavorite } from './lifecycle.service';
+
+	let lifecycleState = $derived(getLifecycleState(propertiesStore.properties));
+	let favorited = $derived(isFavorite(propertiesStore.properties));
+</script>
+
+<div class="flex items-center gap-1 px-3 py-1.5">
+	{#if lifecycleState === 'archived'}
+		<button
+			class="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+			onclick={() => setArchived(false)}
+			title="Unarchive"
+		>
+			<ArchiveRestore class="size-3.5" />
+			Unarchive
+		</button>
+	{:else}
+		{#if lifecycleState === 'inbox'}
+			<button
+				class="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+				onclick={() => setOrganized(true)}
+				title="Mark as organized"
+			>
+				<FolderCheck class="size-3.5" />
+				Organize
+			</button>
+		{:else}
+			<button
+				class="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+				onclick={() => setOrganized(false)}
+				title="Move back to inbox"
+			>
+				<Inbox class="size-3.5" />
+				To Inbox
+			</button>
+		{/if}
+		<button
+			class="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+			onclick={() => setArchived(true)}
+			title="Archive"
+		>
+			<Archive class="size-3.5" />
+			Archive
+		</button>
+	{/if}
+	<button
+		class="ml-auto p-1 rounded-md transition-colors cursor-pointer {favorited ? 'text-yellow-500 hover:text-yellow-600' : 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
+		onclick={() => setFavorite(!favorited)}
+		title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+	>
+		<Star class="size-3.5" fill={favorited ? 'currentColor' : 'none'} />
+	</button>
+</div>

--- a/src/lib/features/properties/PropertiesView.svelte
+++ b/src/lib/features/properties/PropertiesView.svelte
@@ -14,6 +14,7 @@
 	} from './properties.service';
 	import type { PropertyType } from './properties.types';
 	import PropertyField from './PropertyField.svelte';
+	import LifecycleActions from './LifecycleActions.svelte';
 
 	let newKeyInput = $state('');
 	let isAddingProperty = $state(false);
@@ -94,6 +95,10 @@
 		{/if}
 	</div>
 	<Separator />
+	{#if editorStore.activeTab && (!editorStore.activeTab.fileType || editorStore.activeTab.fileType === 'markdown')}
+		<LifecycleActions />
+		<Separator />
+	{/if}
 	<div class="max-h-[50vh] overflow-y-auto p-2">
 		{#if !editorStore.activeTab}
 			<p class="text-muted-foreground px-2 py-4 text-center">No file open</p>

--- a/src/lib/features/properties/lifecycle-filter.logic.ts
+++ b/src/lib/features/properties/lifecycle-filter.logic.ts
@@ -1,0 +1,29 @@
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+
+/** Filters entries to exclude archived notes. */
+export function excludeArchived(entries: NoteEntryV2[]): NoteEntryV2[] {
+	return entries.filter((e) => !e.archived);
+}
+
+/** Returns only archived entries. */
+export function onlyArchived(entries: NoteEntryV2[]): NoteEntryV2[] {
+	return entries.filter((e) => e.archived);
+}
+
+/** Builds a set of archived paths from vault entries. */
+export function buildArchivedPathSet(entries: NoteEntryV2[]): Set<string> {
+	const set = new Set<string>();
+	for (const e of entries) {
+		if (e.archived) set.add(e.path);
+	}
+	return set;
+}
+
+/** Returns the count of archived entries. */
+export function countArchived(entries: NoteEntryV2[]): number {
+	let count = 0;
+	for (const e of entries) {
+		if (e.archived) count++;
+	}
+	return count;
+}

--- a/src/lib/features/properties/lifecycle-filter.service.ts
+++ b/src/lib/features/properties/lifecycle-filter.service.ts
@@ -1,0 +1,11 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import { buildArchivedPathSet } from './lifecycle-filter.logic';
+import { lifecycleFilterStore } from './lifecycle-filter.store.svelte';
+
+/** Fetches all entries and rebuilds the archived path set. */
+export async function refreshArchivedPaths(): Promise<void> {
+	const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
+	const paths = buildArchivedPathSet(entries);
+	lifecycleFilterStore.setArchivedPaths(paths);
+}

--- a/src/lib/features/properties/lifecycle-filter.service.ts
+++ b/src/lib/features/properties/lifecycle-filter.service.ts
@@ -3,9 +3,9 @@ import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 import { buildArchivedPathSet } from './lifecycle-filter.logic';
 import { lifecycleFilterStore } from './lifecycle-filter.store.svelte';
 
-/** Fetches all entries and rebuilds the archived path set. */
-export async function refreshArchivedPaths(): Promise<void> {
-	const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
-	const paths = buildArchivedPathSet(entries);
+/** Rebuilds the archived path set. Fetches entries if not provided. */
+export async function refreshArchivedPaths(entries?: NoteEntryV2[]): Promise<void> {
+	const data = entries ?? await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
+	const paths = buildArchivedPathSet(data);
 	lifecycleFilterStore.setArchivedPaths(paths);
 }

--- a/src/lib/features/properties/lifecycle-filter.store.svelte.ts
+++ b/src/lib/features/properties/lifecycle-filter.store.svelte.ts
@@ -1,0 +1,28 @@
+/**
+ * Reactive store tracking archived note paths.
+ * Rebuilt when vault index updates (vaultIndexVersion pattern).
+ */
+
+let archivedPaths = $state<Set<string>>(new Set());
+let archivedCount = $state(0);
+
+export const lifecycleFilterStore = {
+	get archivedPaths() { return archivedPaths; },
+	get archivedCount() { return archivedCount; },
+
+	/** Returns true if the given path is archived. */
+	isArchived(path: string): boolean {
+		return archivedPaths.has(path);
+	},
+
+	/** Updates the archived path set from vault entries. */
+	setArchivedPaths(paths: Set<string>): void {
+		archivedPaths = paths;
+		archivedCount = paths.size;
+	},
+
+	reset(): void {
+		archivedPaths = new Set();
+		archivedCount = 0;
+	},
+};

--- a/src/lib/features/properties/lifecycle.logic.ts
+++ b/src/lib/features/properties/lifecycle.logic.ts
@@ -1,0 +1,68 @@
+import type { Property } from './properties.types';
+
+/** Lifecycle state derived from frontmatter flags. */
+export type LifecycleState = 'inbox' | 'organized' | 'archived';
+
+/** Returns the lifecycle state of a note from its properties. */
+export function getLifecycleState(properties: Property[]): LifecycleState {
+	const archived = properties.find((p) => p.key === '_archived');
+	if (archived?.value === true) return 'archived';
+	const organized = properties.find((p) => p.key === '_organized');
+	if (organized?.value === true) return 'organized';
+	return 'inbox';
+}
+
+/** Returns whether the note is a favorite. */
+export function isFavorite(properties: Property[]): boolean {
+	const fav = properties.find((p) => p.key === '_favorite');
+	return fav?.value === true;
+}
+
+/**
+ * Sets a boolean flag in properties, creating it if absent.
+ * Returns a new array without mutating the original.
+ */
+export function setBooleanFlag(
+	properties: Property[],
+	key: string,
+	value: boolean,
+): Property[] {
+	const existing = properties.find((p) => p.key === key);
+	if (existing) {
+		return properties.map((p) => (p.key === key ? { ...p, value, type: 'boolean' as const } : p));
+	}
+	return [...properties, { key, value, type: 'boolean' as const }];
+}
+
+/**
+ * Removes a boolean flag from properties (when setting to default/false
+ * and we prefer to not clutter frontmatter).
+ */
+export function removeBooleanFlag(properties: Property[], key: string): Property[] {
+	return properties.filter((p) => p.key !== key);
+}
+
+/**
+ * Toggles the organized state. When marking organized, also removes
+ * archived flag if present.
+ */
+export function toggleOrganized(properties: Property[], organized: boolean): Property[] {
+	let result = setBooleanFlag(properties, '_organized', organized);
+	if (organized) {
+		result = removeBooleanFlag(result, '_archived');
+	}
+	return result;
+}
+
+/**
+ * Toggles the archived state. When archiving, leaves organized as-is.
+ * When unarchiving, returns to previous organized state.
+ */
+export function toggleArchived(properties: Property[], archived: boolean): Property[] {
+	return setBooleanFlag(properties, '_archived', archived);
+}
+
+/** Toggles the favorite flag. */
+export function toggleFavorite(properties: Property[], favorite: boolean): Property[] {
+	return setBooleanFlag(properties, '_favorite', favorite);
+}

--- a/src/lib/features/properties/lifecycle.service.ts
+++ b/src/lib/features/properties/lifecycle.service.ts
@@ -1,0 +1,38 @@
+import { editorStore } from '$lib/core/editor/editor.store.svelte';
+import { syncExternalContentToEditor } from '$lib/core/editor/editor.service';
+import { propertiesStore } from './properties.store.svelte';
+import { extractBody, rebuildContent } from './properties.logic';
+import {
+	toggleOrganized,
+	toggleArchived,
+	toggleFavorite,
+} from './lifecycle.logic';
+import type { Property } from './properties.types';
+
+function commitLifecycleChange(updated: Property[]): void {
+	propertiesStore.setProperties(updated);
+	const body = extractBody(editorStore.activeTab?.content ?? '');
+	const newContent = rebuildContent(updated, body);
+	const activePath = editorStore.activeTabPath;
+	if (activePath) {
+		syncExternalContentToEditor(activePath, newContent, false);
+	}
+}
+
+/** Mark the active note as organized (or not). */
+export function setOrganized(organized: boolean): void {
+	const updated = toggleOrganized(propertiesStore.properties, organized);
+	commitLifecycleChange(updated);
+}
+
+/** Archive or unarchive the active note. */
+export function setArchived(archived: boolean): void {
+	const updated = toggleArchived(propertiesStore.properties, archived);
+	commitLifecycleChange(updated);
+}
+
+/** Toggle favorite on the active note. */
+export function setFavorite(favorite: boolean): void {
+	const updated = toggleFavorite(propertiesStore.properties, favorite);
+	commitLifecycleChange(updated);
+}

--- a/src/lib/features/properties/properties.logic.ts
+++ b/src/lib/features/properties/properties.logic.ts
@@ -1,4 +1,5 @@
 import { parse as yamlParse, Document, type YAMLSeq } from 'yaml';
+import { canonicalizeKey } from '$lib/utils/frontmatter-aliases';
 import type { Property, PropertyType } from './properties.types';
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
@@ -129,9 +130,9 @@ function computeAndCache(rawFrontmatter: string): Property[] {
 	}
 
 	const properties: Property[] = [];
-	for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+	for (const [rawKey, value] of Object.entries(parsed as Record<string, unknown>)) {
 		if (value !== null && typeof value === 'object' && !Array.isArray(value)) continue;
-		properties.push(convertToProperty(key, value));
+		properties.push(convertToProperty(canonicalizeKey(rawKey), value));
 	}
 	parseCache.set(rawFrontmatter, Object.freeze(properties.map(cloneProperty)));
 	evictLru();

--- a/src/lib/features/quick-switcher/QuickSwitcher.svelte
+++ b/src/lib/features/quick-switcher/QuickSwitcher.svelte
@@ -5,9 +5,11 @@
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { toast } from 'svelte-sonner';
 	import { createFile } from '$lib/core/filesystem/fs.service';
+	import { lifecycleFilterStore } from '$lib/features/properties/lifecycle-filter.store.svelte';
 	import { quickSwitcherStore } from './quick-switcher.store.svelte';
 	import { flattenFileTree, filterAndRank, getRelativePath } from './quick-switcher.logic';
 	import FileText from '@lucide/svelte/icons/file-text';
+	import Archive from '@lucide/svelte/icons/archive';
 	import FilePlus from '@lucide/svelte/icons/file-plus';
 
 	let searchQuery = $state('');
@@ -63,13 +65,18 @@
 		{#if hasResults}
 			<Command.Group>
 				{#each filteredFiles as file (file.path)}
+					{@const isArchived = lifecycleFilterStore.isArchived(file.path)}
 					<Command.Item
 						value={file.path}
 						onSelect={() => selectFile(file.path)}
 					>
-						<FileText class="size-4 text-muted-foreground" />
+						{#if isArchived}
+							<Archive class="size-4 text-muted-foreground/50" />
+						{:else}
+							<FileText class="size-4 text-muted-foreground" />
+						{/if}
 						<div class="flex flex-col gap-0.5">
-							<span>{file.nameWithoutExt}</span>
+							<span class={isArchived ? 'opacity-50' : ''}>{file.nameWithoutExt}</span>
 							{#if vaultStore.path}
 								<span class="text-xs text-muted-foreground">
 									{getRelativePath(file.path, vaultStore.path)}

--- a/src/lib/features/type-definitions/SidebarModeToggle.svelte
+++ b/src/lib/features/type-definitions/SidebarModeToggle.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { Button } from '$lib/components/ui/button';
 	import FolderTree from 'lucide-svelte/icons/folder-tree';
 	import LayoutGrid from 'lucide-svelte/icons/layout-grid';
 	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
@@ -14,14 +16,23 @@
 	let isTypesMode = $derived(settingsStore.layout.sidebarMode === 'types');
 </script>
 
-<button
-	class="p-1 rounded-md hover:bg-accent transition-colors cursor-pointer"
-	onclick={toggleMode}
-	title={isTypesMode ? 'Switch to file explorer' : 'Switch to type view'}
->
-	{#if isTypesMode}
-		<FolderTree class="size-3.5 text-muted-foreground" />
-	{:else}
-		<LayoutGrid class="size-3.5 text-muted-foreground" />
-	{/if}
-</button>
+<Tooltip.Root>
+	<Tooltip.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				variant="ghost"
+				size="icon-sm"
+				class="size-6"
+				onclick={toggleMode}
+			>
+				{#if isTypesMode}
+					<FolderTree class="size-3.5" />
+				{:else}
+					<LayoutGrid class="size-3.5" />
+				{/if}
+			</Button>
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content>{isTypesMode ? 'File explorer' : 'Type view'}</Tooltip.Content>
+</Tooltip.Root>

--- a/src/lib/features/type-definitions/SidebarModeToggle.svelte
+++ b/src/lib/features/type-definitions/SidebarModeToggle.svelte
@@ -10,7 +10,7 @@
 	function toggleMode() {
 		const next = settingsStore.layout.sidebarMode === 'files' ? 'types' : 'files';
 		settingsStore.updateLayout({ sidebarMode: next });
-		if (vaultStore.path) saveSettings(vaultStore.path).catch(() => {});
+		if (vaultStore.path) saveSettings(vaultStore.path).catch((err) => { console.error('saveSettings failed:', err); });
 	}
 
 	let isTypesMode = $derived(settingsStore.layout.sidebarMode === 'types');

--- a/src/lib/features/type-definitions/SidebarModeToggle.svelte
+++ b/src/lib/features/type-definitions/SidebarModeToggle.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import FolderTree from 'lucide-svelte/icons/folder-tree';
+	import LayoutGrid from 'lucide-svelte/icons/layout-grid';
+	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
+	import { saveSettings } from '$lib/core/settings/settings.service';
+	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
+
+	function toggleMode() {
+		const next = settingsStore.layout.sidebarMode === 'files' ? 'types' : 'files';
+		settingsStore.updateLayout({ sidebarMode: next });
+		if (vaultStore.path) saveSettings(vaultStore.path).catch(() => {});
+	}
+
+	let isTypesMode = $derived(settingsStore.layout.sidebarMode === 'types');
+</script>
+
+<button
+	class="p-1 rounded-md hover:bg-accent transition-colors cursor-pointer"
+	onclick={toggleMode}
+	title={isTypesMode ? 'Switch to file explorer' : 'Switch to type view'}
+>
+	{#if isTypesMode}
+		<FolderTree class="size-3.5 text-muted-foreground" />
+	{:else}
+		<LayoutGrid class="size-3.5 text-muted-foreground" />
+	{/if}
+</button>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -41,7 +41,7 @@
 			sections = result.sections;
 			untyped = result.untyped;
 			inboxCount = countInbox(entries);
-		} catch { /* service already logs */ }
+		} catch (err) { console.error('TypeSidebar rebuildSections failed:', err); }
 	}
 
 	function toggleSection(name: string) {

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -8,6 +8,7 @@
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
 	import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
@@ -51,6 +52,7 @@
 	}
 </script>
 
+<Tooltip.Provider delayDuration={400}>
 <div class="flex flex-col h-full">
 	<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar shrink-0" data-tauri-drag-region>
 		<div class="flex items-center gap-0.5">
@@ -129,3 +131,4 @@
 		{/if}
 	</div>
 </div>
+</Tooltip.Provider>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { invoke } from '@tauri-apps/api/core';
+	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import FileText from 'lucide-svelte/icons/file-text';
+	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
+	import { openFileInEditor } from '$lib/core/editor/editor.service';
+	import { typeDefinitionsStore } from './type-definitions.store.svelte';
+	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
+	import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+
+	let filter = $state<SidebarFilter>('all');
+	let sections = $state<TypeSection[]>([]);
+	let untyped = $state<TypeSidebarNote[]>([]);
+	let inboxCount = $state(0);
+	let collapsedSections = $state<Set<string>>(new Set());
+
+	$effect(() => {
+		const _version = vaultStore.vaultIndexVersion;
+		if (!vaultStore.isOpen) return;
+		untrack(() => {
+			rebuildSections();
+		});
+	});
+
+	async function rebuildSections() {
+		try {
+			const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
+			const result = buildTypeSections(entries, typeDefinitionsStore.typeMetadataMap, filter);
+			sections = result.sections;
+			untyped = result.untyped;
+			inboxCount = countInbox(entries);
+		} catch { /* service already logs */ }
+	}
+
+	function toggleSection(name: string) {
+		const next = new Set(collapsedSections);
+		if (next.has(name)) next.delete(name);
+		else next.add(name);
+		collapsedSections = next;
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<div class="flex items-center gap-1 px-2 py-1.5 border-b border-border">
+		<button
+			class="px-2 py-0.5 text-xs rounded {filter === 'all' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
+			onclick={() => { filter = 'all'; rebuildSections(); }}
+		>All</button>
+		<button
+			class="px-2 py-0.5 text-xs rounded {filter === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
+			onclick={() => { filter = 'inbox'; rebuildSections(); }}
+		>
+			Inbox
+			{#if inboxCount > 0}
+				<span class="ml-0.5 text-[10px] bg-primary/20 text-primary px-1 rounded-full">{inboxCount}</span>
+			{/if}
+		</button>
+		<button
+			class="px-2 py-0.5 text-xs rounded {filter === 'archived' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
+			onclick={() => { filter = 'archived'; rebuildSections(); }}
+		>Archived</button>
+		<button
+			class="px-2 py-0.5 text-xs rounded {filter === 'favorites' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
+			onclick={() => { filter = 'favorites'; rebuildSections(); }}
+		>Favorites</button>
+	</div>
+
+	<div class="flex-1 overflow-y-auto px-1 py-1">
+		{#each sections as section (section.metadata.name)}
+			{@const collapsed = collapsedSections.has(section.metadata.name)}
+			<div class="mb-1">
+				<button
+					class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
+					onclick={() => toggleSection(section.metadata.name)}
+				>
+					<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
+					<span class="truncate" style="color: var(--color-{section.metadata.color}, inherit)">
+						{section.metadata.sidebarLabel}
+					</span>
+					<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>
+				</button>
+				{#if !collapsed}
+					<div class="pl-4">
+						{#each section.notes as note (note.path)}
+							<button
+								class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
+								onclick={() => openFileInEditor(note.path)}
+							>
+								{note.title}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
+
+		{#if untyped.length > 0}
+			{@const untypedCollapsed = collapsedSections.has('__untyped')}
+			<div class="mb-1 mt-2 border-t border-border pt-1">
+				<button
+					class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors cursor-pointer"
+					onclick={() => toggleSection('__untyped')}
+				>
+					<ChevronRight class="size-3 shrink-0 transition-transform {untypedCollapsed ? '' : 'rotate-90'}" />
+					<FileText class="size-3.5 shrink-0" />
+					<span>Untyped</span>
+					<span class="ml-auto text-xs">{untyped.length}</span>
+				</button>
+				{#if !untypedCollapsed}
+					<div class="pl-4">
+						{#each untyped as note (note.path)}
+							<button
+								class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
+								onclick={() => openFileInEditor(note.path)}
+							>
+								{note.title}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -13,7 +13,7 @@
 	import { editorStore } from '$lib/core/editor/editor.store.svelte';
 	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 	import { fsStore } from '$lib/core/filesystem/fs.store.svelte';
-	import { deleteItem, duplicateItem, revealInSystemExplorer } from '$lib/core/filesystem/fs.service';
+	import { createFile, deleteItem, duplicateItem, revealInSystemExplorer } from '$lib/core/filesystem/fs.service';
 	import { getRelativePath } from '$lib/core/filesystem/fs.logic';
 	import { fileIconsStore } from '$lib/features/file-icons/file-icons.store.svelte';
 	import { getIconSync } from '$lib/features/file-icons/file-icons.icon-data';
@@ -36,6 +36,7 @@
 	let collapsedSections = $state<Set<string>>(new Set());
 	let contextTarget = $state<TypeSidebarNote | null>(null);
 	let sectionContextPath = $state<string | null>(null);
+	let sectionContextName = $state<string | null>(null);
 	let iconPickerPath = $state<string | null>(null);
 	let iconPickerOpen = $state(false);
 	let activePath = $derived(editorStore.activeTabPath);
@@ -120,6 +121,16 @@
 		}
 	}
 
+	async function handleCreateTypeDefinition(typeName: string) {
+		if (!vaultStore.path) return;
+		const content = `---\ntype: Type\n_visible: true\n---\n\n# ${typeName}\n`;
+		const filePath = await createFile(vaultStore.path, `${typeName}.md`);
+		if (!filePath) return;
+		const { writeTextFile } = await import('@tauri-apps/plugin-fs');
+		await writeTextFile(filePath, content);
+		openFileInEditor(filePath);
+	}
+
 	function handleSectionChangeIcon(path: string) {
 		iconPickerPath = path;
 		iconPickerOpen = true;
@@ -187,7 +198,7 @@
 							<button
 								class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none"
 								onclick={() => toggleSection(section.metadata.name)}
-								oncontextmenu={() => { sectionContextPath = defPath; contextTarget = null; }}
+								oncontextmenu={() => { sectionContextPath = defPath; sectionContextName = section.metadata.name; contextTarget = null; }}
 							>
 								<ChevronRight class="size-3.5 shrink-0 text-muted-foreground transition-transform {collapsed ? '' : 'rotate-90'}" />
 								{#if defResolvedIcon}
@@ -288,7 +299,7 @@
 			{/snippet}
 		</ContextMenu.Trigger>
 		<ContextMenu.Content class="w-56">
-			{#if sectionContextPath}
+			{#if sectionContextName && sectionContextPath}
 				{@const path = sectionContextPath}
 				<ContextMenu.Item onclick={() => openFileInEditor(path)}>
 					<ExternalLink class="size-4" />
@@ -298,6 +309,12 @@
 				<ContextMenu.Item onclick={() => handleSectionChangeIcon(path)}>
 					<Palette class="size-4" />
 					<span>Change icon</span>
+				</ContextMenu.Item>
+			{:else if sectionContextName && !sectionContextPath}
+				{@const name = sectionContextName}
+				<ContextMenu.Item onclick={() => handleCreateTypeDefinition(name)}>
+					<FileText class="size-4" />
+					<span>Create type definition</span>
 				</ContextMenu.Item>
 			{:else if contextTarget}
 				{@const target = contextTarget}

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -9,6 +9,7 @@
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
+	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
 	import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 
 	let filter = $state<SidebarFilter>('all');
@@ -17,6 +18,12 @@
 	let inboxCount = $state(0);
 	let collapsedSections = $state<Set<string>>(new Set());
 	let inboxEnabled = $derived(settingsStore.settings.explicitOrganization);
+	let filterTabs = $derived([
+		{ id: 'all' as SidebarFilter, label: 'All' },
+		...(inboxEnabled ? [{ id: 'inbox' as SidebarFilter, label: 'Inbox' }] : []),
+		{ id: 'archived' as SidebarFilter, label: 'Archived' },
+		{ id: 'favorites' as SidebarFilter, label: 'Favorites' },
+	]);
 
 	$effect(() => {
 		const _version = vaultStore.vaultIndexVersion;
@@ -46,32 +53,23 @@
 
 <div class="flex flex-col h-full">
 	<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar shrink-0" data-tauri-drag-region>
-		<SidebarModeToggle />
+		<div class="flex items-center gap-0.5">
+			<DailyNoteButton />
+			<SidebarModeToggle />
+		</div>
 	</div>
-	<div class="flex items-center gap-1 px-2 py-1.5 border-b border-border">
-		<button
-			class="px-2 py-0.5 text-xs rounded {filter === 'all' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
-			onclick={() => { filter = 'all'; rebuildSections(); }}
-		>All</button>
-		{#if inboxEnabled}
+	<div class="flex items-center border-b border-border shrink-0">
+		{#each filterTabs as f (f.id)}
 			<button
-				class="px-2 py-0.5 text-xs rounded {filter === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
-				onclick={() => { filter = 'inbox'; rebuildSections(); }}
+				class="flex-1 px-2 py-1.5 text-xs font-medium transition-colors cursor-pointer border-b-2 {filter === f.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+				onclick={() => { filter = f.id as SidebarFilter; rebuildSections(); }}
 			>
-				Inbox
-				{#if inboxCount > 0}
+				{f.label}
+				{#if f.id === 'inbox' && inboxCount > 0}
 					<span class="ml-0.5 text-[10px] bg-primary/20 text-primary px-1 rounded-full">{inboxCount}</span>
 				{/if}
 			</button>
-		{/if}
-		<button
-			class="px-2 py-0.5 text-xs rounded {filter === 'archived' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
-			onclick={() => { filter = 'archived'; rebuildSections(); }}
-		>Archived</button>
-		<button
-			class="px-2 py-0.5 text-xs rounded {filter === 'favorites' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
-			onclick={() => { filter = 'favorites'; rebuildSections(); }}
-		>Favorites</button>
+		{/each}
 	</div>
 
 	<div class="flex-1 overflow-y-auto px-1 py-1">

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -310,6 +310,11 @@
 					<Palette class="size-4" />
 					<span>Change icon</span>
 				</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Item onclick={() => revealInSystemExplorer(path)}>
+					<FolderSearch class="size-4" />
+					<span>Reveal in Finder</span>
+				</ContextMenu.Item>
 			{:else if sectionContextName && !sectionContextPath}
 				{@const name = sectionContextName}
 				<ContextMenu.Item onclick={() => handleCreateTypeDefinition(name)}>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ask } from '@tauri-apps/plugin-dialog';
+	import { icons } from '@lucide/svelte';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import FileText from 'lucide-svelte/icons/file-text';
 	import ExternalLink from 'lucide-svelte/icons/external-link';
@@ -9,10 +10,14 @@
 	import Trash2 from 'lucide-svelte/icons/trash-2';
 	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
+	import { editorStore } from '$lib/core/editor/editor.store.svelte';
 	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 	import { fsStore } from '$lib/core/filesystem/fs.store.svelte';
 	import { deleteItem, duplicateItem, revealInSystemExplorer } from '$lib/core/filesystem/fs.service';
 	import { getRelativePath } from '$lib/core/filesystem/fs.logic';
+	import { fileIconsStore } from '$lib/features/file-icons/file-icons.store.svelte';
+	import { getIconSync } from '$lib/features/file-icons/file-icons.icon-data';
+	import IconRenderer from '$lib/features/file-icons/IconRenderer.svelte';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
 	import * as Tooltip from '$lib/components/ui/tooltip';
@@ -20,12 +25,33 @@
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
 
+	const TYPE_COLORS: Record<string, string> = {
+		red: '#ef4444',
+		blue: '#3b82f6',
+		purple: '#a855f7',
+		green: '#22c55e',
+		orange: '#f97316',
+		yellow: '#eab308',
+		pink: '#ec4899',
+		gray: '#9ca3af',
+	};
+
+	function toPascalCase(s: string): string {
+		return s.replace(/(^|[-_])(\w)/g, (_, __, c) => c.toUpperCase());
+	}
+
+	function getIconComponent(iconName: string) {
+		const key = toPascalCase(iconName) as keyof typeof icons;
+		return (icons[key] as unknown as typeof FileText) ?? FileText;
+	}
+
 	let filter = $state<SidebarFilter>('all');
 	let sections = $state<TypeSection[]>([]);
 	let untyped = $state<TypeSidebarNote[]>([]);
 	let inboxCount = $state(0);
 	let collapsedSections = $state<Set<string>>(new Set());
 	let contextTarget = $state<TypeSidebarNote | null>(null);
+	let activePath = $derived(editorStore.activeTabPath);
 	let inboxEnabled = $derived(settingsStore.settings.explicitOrganization);
 	let filterTabs = $derived([
 		{ id: 'all' as SidebarFilter, label: 'All' },
@@ -33,6 +59,8 @@
 		{ id: 'archived' as SidebarFilter, label: 'Archived' },
 		{ id: 'favorites' as SidebarFilter, label: 'Favorites' },
 	]);
+
+	let initialized = false;
 
 	$effect(() => {
 		const _version = typeDefinitionsStore.entriesVersion;
@@ -42,6 +70,13 @@
 		sections = result.sections;
 		untyped = result.untyped;
 		inboxCount = countInbox(entries);
+		if (!initialized) {
+			initialized = true;
+			const collapsed = new Set<string>();
+			for (const s of result.sections) collapsed.add(s.metadata.name);
+			if (result.untyped.length > 0) collapsed.add('__untyped');
+			collapsedSections = collapsed;
+		}
 	});
 
 	function rebuildFromCache() {
@@ -124,13 +159,16 @@
 				<div {...props} class="flex-1 overflow-y-auto px-1 py-1">
 					{#each sections as section (section.metadata.name)}
 						{@const collapsed = collapsedSections.has(section.metadata.name)}
+						{@const SectionIcon = getIconComponent(section.metadata.icon)}
+						{@const sectionColor = TYPE_COLORS[section.metadata.color] ?? TYPE_COLORS.gray}
 						<div class="mb-1">
 							<button
 								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
 								onclick={() => toggleSection(section.metadata.name)}
 							>
 								<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
-								<span class="truncate" style="color: var(--color-{section.metadata.color}, inherit)">
+								<SectionIcon class="size-3.5 shrink-0" style="color: {sectionColor}" />
+								<span class="truncate" style="color: {sectionColor}">
 									{section.metadata.sidebarLabel}
 								</span>
 								<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>
@@ -138,13 +176,31 @@
 							{#if !collapsed}
 								<div class="pl-4">
 									{#each section.notes as note (note.path)}
-										<button
-											class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
-											onclick={() => openFileInEditor(note.path)}
-											oncontextmenu={() => { contextTarget = note; }}
-										>
-											{note.title}
-										</button>
+										{@const customEntry = fileIconsStore.getIcon(note.path)}
+										{@const fmRef = fileIconsStore.getFrontmatterIcon(note.path)}
+										{@const customIcon = customEntry ? getIconSync(customEntry.iconPack, customEntry.iconName) : undefined}
+										{@const fmIcon = fmRef ? getIconSync(fmRef.iconPack, fmRef.iconName) : undefined}
+										{@const resolvedIcon = fmIcon ?? customIcon}
+										{@const iconColor = fmIcon ? undefined : customEntry?.color}
+										{@const isActive = note.path === activePath}
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props: tipProps })}
+													<button
+														{...tipProps}
+														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+														onclick={() => openFileInEditor(note.path)}
+														oncontextmenu={() => { contextTarget = note; }}
+													>
+														{#if resolvedIcon}
+															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
+														{/if}
+														<span class="truncate">{note.title}</span>
+													</button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content side="right">{note.title}</Tooltip.Content>
+										</Tooltip.Root>
 									{/each}
 								</div>
 							{/if}
@@ -166,13 +222,31 @@
 							{#if !untypedCollapsed}
 								<div class="pl-4">
 									{#each untyped as note (note.path)}
-										<button
-											class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
-											onclick={() => openFileInEditor(note.path)}
-											oncontextmenu={() => { contextTarget = note; }}
-										>
-											{note.title}
-										</button>
+										{@const customEntry = fileIconsStore.getIcon(note.path)}
+										{@const fmRef = fileIconsStore.getFrontmatterIcon(note.path)}
+										{@const customIcon = customEntry ? getIconSync(customEntry.iconPack, customEntry.iconName) : undefined}
+										{@const fmIcon = fmRef ? getIconSync(fmRef.iconPack, fmRef.iconName) : undefined}
+										{@const resolvedIcon = fmIcon ?? customIcon}
+										{@const iconColor = fmIcon ? undefined : customEntry?.color}
+										{@const isActive = note.path === activePath}
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props: tipProps })}
+													<button
+														{...tipProps}
+														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+														onclick={() => openFileInEditor(note.path)}
+														oncontextmenu={() => { contextTarget = note; }}
+													>
+														{#if resolvedIcon}
+															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
+														{/if}
+														<span class="truncate">{note.title}</span>
+													</button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content side="right">{note.title}</Tooltip.Content>
+										</Tooltip.Root>
 									{/each}
 								</div>
 							{/if}

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -43,8 +43,9 @@
 </script>
 
 <div class="flex flex-col h-full">
-	<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
+	<div class="flex items-center h-10 px-3 bg-tab-bar shrink-0" data-tauri-drag-region>
 		<SidebarModeToggle />
+		<span class="ml-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">Types</span>
 	</div>
 	<div class="flex items-center gap-1 px-2 py-1.5 border-b border-border">
 		<button

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -7,6 +7,7 @@
 	import Pencil from 'lucide-svelte/icons/pencil';
 	import FolderSearch from 'lucide-svelte/icons/folder-search';
 	import Trash2 from 'lucide-svelte/icons/trash-2';
+	import Palette from 'lucide-svelte/icons/palette';
 	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { editorStore } from '$lib/core/editor/editor.store.svelte';
@@ -16,7 +17,10 @@
 	import { getRelativePath } from '$lib/core/filesystem/fs.logic';
 	import { fileIconsStore } from '$lib/features/file-icons/file-icons.store.svelte';
 	import { getIconSync } from '$lib/features/file-icons/file-icons.icon-data';
+	import { setIconForPath, removeIconForPath, trackRecentIcon } from '$lib/features/file-icons/file-icons.service';
 	import IconRenderer from '$lib/features/file-icons/IconRenderer.svelte';
+	import IconPicker from '$lib/features/file-icons/IconPicker.svelte';
+	import type { IconPackId } from '$lib/features/file-icons/file-icons.types';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
 	import * as Tooltip from '$lib/components/ui/tooltip';
@@ -30,8 +34,14 @@
 	let inboxCount = $state(0);
 	let collapsedSections = $state<Set<string>>(new Set());
 	let contextTarget = $state<TypeSidebarNote | null>(null);
+	let sectionContextPath = $state<string | null>(null);
+	let iconPickerPath = $state<string | null>(null);
+	let iconPickerOpen = $state(false);
 	let activePath = $derived(editorStore.activeTabPath);
 	let inboxEnabled = $derived(settingsStore.settings.explicitOrganization);
+	let iconPickerEntry = $derived(
+		iconPickerPath ? fileIconsStore.getIcon(iconPickerPath) : undefined
+	);
 	let filterTabs = $derived([
 		{ id: 'all' as SidebarFilter, label: 'All' },
 		...(inboxEnabled ? [{ id: 'inbox' as SidebarFilter, label: 'Inbox' }] : []),
@@ -108,6 +118,27 @@
 			await deleteItem(note.path, false);
 		}
 	}
+
+	function handleSectionChangeIcon(path: string) {
+		iconPickerPath = path;
+		iconPickerOpen = true;
+	}
+
+	async function handleIconSelect(pack: IconPackId, name: string, color?: string, textColor?: string) {
+		if (!vaultStore.path || !iconPickerPath) return;
+		await setIconForPath(vaultStore.path, iconPickerPath, pack, name, color, textColor);
+		await trackRecentIcon(vaultStore.path, pack, name);
+	}
+
+	async function handleIconRemove() {
+		if (!vaultStore.path || !iconPickerPath) return;
+		await removeIconForPath(vaultStore.path, iconPickerPath);
+	}
+
+	function handleIconPickerClose() {
+		iconPickerOpen = false;
+		iconPickerPath = null;
+	}
 </script>
 
 <Tooltip.Provider delayDuration={400}>
@@ -138,12 +169,23 @@
 				<div {...props} class="flex-1 overflow-y-auto px-1 py-1">
 					{#each sections as section (section.metadata.name)}
 						{@const collapsed = collapsedSections.has(section.metadata.name)}
+						{@const defPath = section.definitionPath}
+						{@const defIconEntry = defPath ? fileIconsStore.getIcon(defPath) : undefined}
+						{@const defFmRef = defPath ? fileIconsStore.getFrontmatterIcon(defPath) : undefined}
+						{@const defCustomIcon = defIconEntry ? getIconSync(defIconEntry.iconPack, defIconEntry.iconName) : undefined}
+						{@const defFmIcon = defFmRef ? getIconSync(defFmRef.iconPack, defFmRef.iconName) : undefined}
+						{@const defResolvedIcon = defFmIcon ?? defCustomIcon}
+						{@const defIconColor = defFmIcon ? undefined : defIconEntry?.color}
 						<div class="mb-1">
 							<button
 								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
 								onclick={() => toggleSection(section.metadata.name)}
+								oncontextmenu={() => { sectionContextPath = defPath; contextTarget = null; }}
 							>
 								<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
+								{#if defResolvedIcon}
+									<IconRenderer icon={defResolvedIcon} class="size-3.5 shrink-0" color={defIconColor} />
+								{/if}
 								<span class="truncate">
 									{section.metadata.sidebarLabel}
 								</span>
@@ -166,7 +208,7 @@
 														{...tipProps}
 														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
 														onclick={() => openFileInEditor(note.path)}
-														oncontextmenu={() => { contextTarget = note; }}
+														oncontextmenu={() => { contextTarget = note; sectionContextPath = null; }}
 													>
 														{#if resolvedIcon}
 															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
@@ -212,7 +254,7 @@
 														{...tipProps}
 														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
 														onclick={() => openFileInEditor(note.path)}
-														oncontextmenu={() => { contextTarget = note; }}
+														oncontextmenu={() => { contextTarget = note; sectionContextPath = null; }}
 													>
 														{#if resolvedIcon}
 															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
@@ -232,7 +274,18 @@
 			{/snippet}
 		</ContextMenu.Trigger>
 		<ContextMenu.Content class="w-56">
-			{#if contextTarget}
+			{#if sectionContextPath}
+				{@const path = sectionContextPath}
+				<ContextMenu.Item onclick={() => openFileInEditor(path)}>
+					<ExternalLink class="size-4" />
+					<span>Open type definition</span>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Item onclick={() => handleSectionChangeIcon(path)}>
+					<Palette class="size-4" />
+					<span>Change icon</span>
+				</ContextMenu.Item>
+			{:else if contextTarget}
 				{@const target = contextTarget}
 				<ContextMenu.Item onclick={() => handleOpenInNewTab(target)}>
 					<ExternalLink class="size-4" />
@@ -283,3 +336,16 @@
 	</ContextMenu.Root>
 </div>
 </Tooltip.Provider>
+
+{#if iconPickerPath}
+	<IconPicker
+		bind:open={iconPickerOpen}
+		currentPack={iconPickerEntry?.iconPack}
+		currentName={iconPickerEntry?.iconName}
+		currentColor={iconPickerEntry?.color}
+		currentTextColor={iconPickerEntry?.textColor}
+		onSelect={handleIconSelect}
+		onRemove={handleIconRemove}
+		onClose={handleIconPickerClose}
+	/>
+{/if}

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { ask } from '@tauri-apps/plugin-dialog';
-	import { icons } from '@lucide/svelte';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import FileText from 'lucide-svelte/icons/file-text';
 	import ExternalLink from 'lucide-svelte/icons/external-link';
@@ -24,26 +23,6 @@
 	import * as ContextMenu from '$lib/components/ui/context-menu';
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
-
-	const TYPE_COLORS: Record<string, string> = {
-		red: '#ef4444',
-		blue: '#3b82f6',
-		purple: '#a855f7',
-		green: '#22c55e',
-		orange: '#f97316',
-		yellow: '#eab308',
-		pink: '#ec4899',
-		gray: '#9ca3af',
-	};
-
-	function toPascalCase(s: string): string {
-		return s.replace(/(^|[-_])(\w)/g, (_, __, c) => c.toUpperCase());
-	}
-
-	function getIconComponent(iconName: string) {
-		const key = toPascalCase(iconName) as keyof typeof icons;
-		return (icons[key] as unknown as typeof FileText) ?? FileText;
-	}
 
 	let filter = $state<SidebarFilter>('all');
 	let sections = $state<TypeSection[]>([]);
@@ -159,16 +138,13 @@
 				<div {...props} class="flex-1 overflow-y-auto px-1 py-1">
 					{#each sections as section (section.metadata.name)}
 						{@const collapsed = collapsedSections.has(section.metadata.name)}
-						{@const SectionIcon = getIconComponent(section.metadata.icon)}
-						{@const sectionColor = TYPE_COLORS[section.metadata.color] ?? TYPE_COLORS.gray}
 						<div class="mb-1">
 							<button
 								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
 								onclick={() => toggleSection(section.metadata.name)}
 							>
 								<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
-								<SectionIcon class="size-3.5 shrink-0" style="color: {sectionColor}" />
-								<span class="truncate" style="color: {sectionColor}">
+								<span class="truncate">
 									{section.metadata.sidebarLabel}
 								</span>
 								<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
-	import { invoke } from '@tauri-apps/api/core';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import FileText from 'lucide-svelte/icons/file-text';
-	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
 	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
@@ -11,7 +8,6 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
-	import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 
 	let filter = $state<SidebarFilter>('all');
 	let sections = $state<TypeSection[]>([]);
@@ -27,21 +23,21 @@
 	]);
 
 	$effect(() => {
-		const _version = vaultStore.vaultIndexVersion;
-		if (!vaultStore.isOpen) return;
-		untrack(() => {
-			rebuildSections();
-		});
+		const _version = typeDefinitionsStore.entriesVersion;
+		const entries = typeDefinitionsStore.entries;
+		if (entries.length === 0) return;
+		const result = buildTypeSections(entries, typeDefinitionsStore.typeMetadataMap, filter);
+		sections = result.sections;
+		untyped = result.untyped;
+		inboxCount = countInbox(entries);
 	});
 
-	async function rebuildSections() {
-		try {
-			const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
-			const result = buildTypeSections(entries, typeDefinitionsStore.typeMetadataMap, filter);
-			sections = result.sections;
-			untyped = result.untyped;
-			inboxCount = countInbox(entries);
-		} catch (err) { console.error('TypeSidebar rebuildSections failed:', err); }
+	function rebuildFromCache() {
+		const entries = typeDefinitionsStore.entries;
+		const result = buildTypeSections(entries, typeDefinitionsStore.typeMetadataMap, filter);
+		sections = result.sections;
+		untyped = result.untyped;
+		inboxCount = countInbox(entries);
 	}
 
 	function toggleSection(name: string) {
@@ -64,7 +60,7 @@
 		{#each filterTabs as f (f.id)}
 			<button
 				class="flex-1 px-2 py-1.5 text-xs font-medium transition-colors cursor-pointer border-b-2 {filter === f.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
-				onclick={() => { filter = f.id as SidebarFilter; rebuildSections(); }}
+				onclick={() => { filter = f.id as SidebarFilter; rebuildFromCache(); }}
 			>
 				{f.label}
 				{#if f.id === 'inbox' && inboxCount > 0}

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -22,6 +22,7 @@
 	import IconPicker from '$lib/features/file-icons/IconPicker.svelte';
 	import type { IconPackId } from '$lib/features/file-icons/file-icons.types';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
+	import { updateTypeDefinitionIcon } from './type-definitions.service';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import * as ContextMenu from '$lib/components/ui/context-menu';
@@ -128,6 +129,11 @@
 		if (!vaultStore.path || !iconPickerPath) return;
 		await setIconForPath(vaultStore.path, iconPickerPath, pack, name, color, textColor);
 		await trackRecentIcon(vaultStore.path, pack, name);
+		if (sectionContextPath === iconPickerPath) {
+			await updateTypeDefinitionIcon(iconPickerPath, name, color ?? null).catch((err) => {
+				console.error('updateTypeDefinitionIcon failed:', err);
+			});
+		}
 	}
 
 	async function handleIconRemove() {
@@ -176,6 +182,7 @@
 						{@const defFmIcon = defFmRef ? getIconSync(defFmRef.iconPack, defFmRef.iconName) : undefined}
 						{@const defResolvedIcon = defFmIcon ?? defCustomIcon}
 						{@const defIconColor = defFmIcon ? undefined : defIconEntry?.color}
+						{@const defTextColor = defFmIcon ? undefined : defIconEntry?.textColor}
 						<div class="mb-1">
 							<button
 								class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none"
@@ -186,7 +193,7 @@
 								{#if defResolvedIcon}
 									<IconRenderer icon={defResolvedIcon} class="size-4 shrink-0" color={defIconColor} />
 								{/if}
-								<span class="truncate">
+								<span class="truncate" style:color={defTextColor ?? undefined}>
 									{section.metadata.sidebarLabel}
 								</span>
 								<span class="ml-auto shrink-0 pr-1 text-xs text-[#8a8faa]">{section.notes.length}</span>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -7,6 +7,7 @@
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
+	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 
 	let filter = $state<SidebarFilter>('all');
@@ -42,6 +43,9 @@
 </script>
 
 <div class="flex flex-col h-full">
+	<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar" data-tauri-drag-region>
+		<SidebarModeToggle />
+	</div>
 	<div class="flex items-center gap-1 px-2 py-1.5 border-b border-border">
 		<button
 			class="px-2 py-0.5 text-xs rounded {filter === 'all' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -4,6 +4,7 @@
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import FileText from 'lucide-svelte/icons/file-text';
 	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
+	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
@@ -15,6 +16,7 @@
 	let untyped = $state<TypeSidebarNote[]>([]);
 	let inboxCount = $state(0);
 	let collapsedSections = $state<Set<string>>(new Set());
+	let inboxEnabled = $derived(settingsStore.settings.explicitOrganization);
 
 	$effect(() => {
 		const _version = vaultStore.vaultIndexVersion;
@@ -43,24 +45,25 @@
 </script>
 
 <div class="flex flex-col h-full">
-	<div class="flex items-center h-10 px-3 bg-tab-bar shrink-0" data-tauri-drag-region>
+	<div class="flex items-center justify-end h-10 px-3 gap-0.5 bg-tab-bar shrink-0" data-tauri-drag-region>
 		<SidebarModeToggle />
-		<span class="ml-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">Types</span>
 	</div>
 	<div class="flex items-center gap-1 px-2 py-1.5 border-b border-border">
 		<button
 			class="px-2 py-0.5 text-xs rounded {filter === 'all' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
 			onclick={() => { filter = 'all'; rebuildSections(); }}
 		>All</button>
-		<button
-			class="px-2 py-0.5 text-xs rounded {filter === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
-			onclick={() => { filter = 'inbox'; rebuildSections(); }}
-		>
-			Inbox
-			{#if inboxCount > 0}
-				<span class="ml-0.5 text-[10px] bg-primary/20 text-primary px-1 rounded-full">{inboxCount}</span>
-			{/if}
-		</button>
+		{#if inboxEnabled}
+			<button
+				class="px-2 py-0.5 text-xs rounded {filter === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
+				onclick={() => { filter = 'inbox'; rebuildSections(); }}
+			>
+				Inbox
+				{#if inboxCount > 0}
+					<span class="ml-0.5 text-[10px] bg-primary/20 text-primary px-1 rounded-full">{inboxCount}</span>
+				{/if}
+			</button>
+		{/if}
 		<button
 			class="px-2 py-0.5 text-xs rounded {filter === 'archived' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'} cursor-pointer"
 			onclick={() => { filter = 'archived'; rebuildSections(); }}

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -103,7 +103,7 @@
 			</div>
 		{/each}
 
-		{#if untyped.length > 0}
+		{#if untyped.length > 0 && settingsStore.showUntypedNotes}
 			{@const untypedCollapsed = collapsedSections.has('__untyped')}
 			<div class="mb-1 mt-2 border-t border-border pt-1">
 				<button

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
+	import { ask } from '@tauri-apps/plugin-dialog';
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import FileText from 'lucide-svelte/icons/file-text';
+	import ExternalLink from 'lucide-svelte/icons/external-link';
+	import Copy from 'lucide-svelte/icons/copy';
+	import Pencil from 'lucide-svelte/icons/pencil';
+	import FolderSearch from 'lucide-svelte/icons/folder-search';
+	import Trash2 from 'lucide-svelte/icons/trash-2';
 	import { settingsStore } from '$lib/core/settings/settings.store.svelte';
 	import { openFileInEditor } from '$lib/core/editor/editor.service';
+	import { vaultStore } from '$lib/core/vault/vault.store.svelte';
+	import { fsStore } from '$lib/core/filesystem/fs.store.svelte';
+	import { deleteItem, duplicateItem, revealInSystemExplorer } from '$lib/core/filesystem/fs.service';
+	import { getRelativePath } from '$lib/core/filesystem/fs.logic';
 	import { typeDefinitionsStore } from './type-definitions.store.svelte';
 	import { buildTypeSections, countInbox, type SidebarFilter, type TypeSection, type TypeSidebarNote } from './type-sidebar.logic';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import * as ContextMenu from '$lib/components/ui/context-menu';
 	import SidebarModeToggle from './SidebarModeToggle.svelte';
 	import DailyNoteButton from '$lib/plugins/periodic-notes/DailyNoteButton.svelte';
 
@@ -14,6 +25,7 @@
 	let untyped = $state<TypeSidebarNote[]>([]);
 	let inboxCount = $state(0);
 	let collapsedSections = $state<Set<string>>(new Set());
+	let contextTarget = $state<TypeSidebarNote | null>(null);
 	let inboxEnabled = $derived(settingsStore.settings.explicitOrganization);
 	let filterTabs = $derived([
 		{ id: 'all' as SidebarFilter, label: 'All' },
@@ -46,6 +58,42 @@
 		else next.add(name);
 		collapsedSections = next;
 	}
+
+	async function handleOpenInNewTab(note: TypeSidebarNote) {
+		openFileInEditor(note.path);
+	}
+
+	async function handleDuplicate(note: TypeSidebarNote) {
+		await duplicateItem(note.path, false);
+	}
+
+	async function handleCopyAbsolutePath(note: TypeSidebarNote) {
+		await navigator.clipboard.writeText(note.path);
+	}
+
+	async function handleCopyRelativePath(note: TypeSidebarNote) {
+		if (!vaultStore.path) return;
+		await navigator.clipboard.writeText(getRelativePath(vaultStore.path, note.path));
+	}
+
+	async function handleRevealInFinder(note: TypeSidebarNote) {
+		await revealInSystemExplorer(note.path);
+	}
+
+	function handleStartRename(note: TypeSidebarNote) {
+		fsStore.setRenamingPath(note.path);
+		settingsStore.updateLayout({ sidebarMode: 'files' });
+	}
+
+	async function handleDelete(note: TypeSidebarNote) {
+		const confirmed = await ask(
+			`Move "${note.title}" to trash?`,
+			{ title: 'Move to Trash', kind: 'warning' }
+		);
+		if (confirmed) {
+			await deleteItem(note.path, false);
+		}
+	}
 </script>
 
 <Tooltip.Provider delayDuration={400}>
@@ -70,61 +118,118 @@
 		{/each}
 	</div>
 
-	<div class="flex-1 overflow-y-auto px-1 py-1">
-		{#each sections as section (section.metadata.name)}
-			{@const collapsed = collapsedSections.has(section.metadata.name)}
-			<div class="mb-1">
-				<button
-					class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
-					onclick={() => toggleSection(section.metadata.name)}
-				>
-					<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
-					<span class="truncate" style="color: var(--color-{section.metadata.color}, inherit)">
-						{section.metadata.sidebarLabel}
-					</span>
-					<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>
-				</button>
-				{#if !collapsed}
-					<div class="pl-4">
-						{#each section.notes as note (note.path)}
+	<ContextMenu.Root>
+		<ContextMenu.Trigger>
+			{#snippet child({ props })}
+				<div {...props} class="flex-1 overflow-y-auto px-1 py-1">
+					{#each sections as section (section.metadata.name)}
+						{@const collapsed = collapsedSections.has(section.metadata.name)}
+						<div class="mb-1">
 							<button
-								class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
-								onclick={() => openFileInEditor(note.path)}
+								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
+								onclick={() => toggleSection(section.metadata.name)}
 							>
-								{note.title}
+								<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
+								<span class="truncate" style="color: var(--color-{section.metadata.color}, inherit)">
+									{section.metadata.sidebarLabel}
+								</span>
+								<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>
 							</button>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{/each}
+							{#if !collapsed}
+								<div class="pl-4">
+									{#each section.notes as note (note.path)}
+										<button
+											class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
+											onclick={() => openFileInEditor(note.path)}
+											oncontextmenu={() => { contextTarget = note; }}
+										>
+											{note.title}
+										</button>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/each}
 
-		{#if untyped.length > 0 && settingsStore.showUntypedNotes}
-			{@const untypedCollapsed = collapsedSections.has('__untyped')}
-			<div class="mb-1 mt-2 border-t border-border pt-1">
-				<button
-					class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors cursor-pointer"
-					onclick={() => toggleSection('__untyped')}
-				>
-					<ChevronRight class="size-3 shrink-0 transition-transform {untypedCollapsed ? '' : 'rotate-90'}" />
-					<FileText class="size-3.5 shrink-0" />
-					<span>Untyped</span>
-					<span class="ml-auto text-xs">{untyped.length}</span>
-				</button>
-				{#if !untypedCollapsed}
-					<div class="pl-4">
-						{#each untyped as note (note.path)}
+					{#if untyped.length > 0 && settingsStore.showUntypedNotes}
+						{@const untypedCollapsed = collapsedSections.has('__untyped')}
+						<div class="mb-1 mt-2 border-t border-border pt-1">
 							<button
-								class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
-								onclick={() => openFileInEditor(note.path)}
+								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors cursor-pointer"
+								onclick={() => toggleSection('__untyped')}
 							>
-								{note.title}
+								<ChevronRight class="size-3 shrink-0 transition-transform {untypedCollapsed ? '' : 'rotate-90'}" />
+								<FileText class="size-3.5 shrink-0" />
+								<span>Untyped</span>
+								<span class="ml-auto text-xs">{untyped.length}</span>
 							</button>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{/if}
-	</div>
+							{#if !untypedCollapsed}
+								<div class="pl-4">
+									{#each untyped as note (note.path)}
+										<button
+											class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors truncate cursor-pointer"
+											onclick={() => openFileInEditor(note.path)}
+											oncontextmenu={() => { contextTarget = note; }}
+										>
+											{note.title}
+										</button>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/snippet}
+		</ContextMenu.Trigger>
+		<ContextMenu.Content class="w-56">
+			{#if contextTarget}
+				{@const target = contextTarget}
+				<ContextMenu.Item onclick={() => handleOpenInNewTab(target)}>
+					<ExternalLink class="size-4" />
+					<span>Open in new tab</span>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+
+				<ContextMenu.Item onclick={() => handleDuplicate(target)}>
+					<Copy class="size-4" />
+					<span>Duplicate</span>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+
+				<ContextMenu.Sub>
+					<ContextMenu.SubTrigger>
+						<Copy class="size-4" />
+						<span>Copy path</span>
+					</ContextMenu.SubTrigger>
+					<ContextMenu.SubContent>
+						<ContextMenu.Item onclick={() => handleCopyAbsolutePath(target)}>
+							<span>Copy absolute path</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item onclick={() => handleCopyRelativePath(target)}>
+							<span>Copy relative path</span>
+						</ContextMenu.Item>
+					</ContextMenu.SubContent>
+				</ContextMenu.Sub>
+				<ContextMenu.Separator />
+
+				<ContextMenu.Item onclick={() => handleRevealInFinder(target)}>
+					<FolderSearch class="size-4" />
+					<span>Reveal in Finder</span>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+
+				<ContextMenu.Item onclick={() => handleStartRename(target)}>
+					<Pencil class="size-4" />
+					<span>Rename</span>
+					<ContextMenu.Shortcut>F2</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Item variant="destructive" onclick={() => handleDelete(target)}>
+					<Trash2 class="size-4" />
+					<span>Move to Trash</span>
+					<ContextMenu.Shortcut>⌘⌫</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+			{/if}
+		</ContextMenu.Content>
+	</ContextMenu.Root>
 </div>
 </Tooltip.Provider>

--- a/src/lib/features/type-definitions/TypeSidebar.svelte
+++ b/src/lib/features/type-definitions/TypeSidebar.svelte
@@ -178,21 +178,21 @@
 						{@const defIconColor = defFmIcon ? undefined : defIconEntry?.color}
 						<div class="mb-1">
 							<button
-								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors cursor-pointer"
+								class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none"
 								onclick={() => toggleSection(section.metadata.name)}
 								oncontextmenu={() => { sectionContextPath = defPath; contextTarget = null; }}
 							>
-								<ChevronRight class="size-3 shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}" />
+								<ChevronRight class="size-3.5 shrink-0 text-muted-foreground transition-transform {collapsed ? '' : 'rotate-90'}" />
 								{#if defResolvedIcon}
-									<IconRenderer icon={defResolvedIcon} class="size-3.5 shrink-0" color={defIconColor} />
+									<IconRenderer icon={defResolvedIcon} class="size-4 shrink-0" color={defIconColor} />
 								{/if}
 								<span class="truncate">
 									{section.metadata.sidebarLabel}
 								</span>
-								<span class="ml-auto text-xs text-muted-foreground">{section.notes.length}</span>
+								<span class="ml-auto shrink-0 pr-1 text-xs text-[#8a8faa]">{section.notes.length}</span>
 							</button>
 							{#if !collapsed}
-								<div class="pl-4">
+								<div>
 									{#each section.notes as note (note.path)}
 										{@const customEntry = fileIconsStore.getIcon(note.path)}
 										{@const fmRef = fileIconsStore.getFrontmatterIcon(note.path)}
@@ -200,20 +200,24 @@
 										{@const fmIcon = fmRef ? getIconSync(fmRef.iconPack, fmRef.iconName) : undefined}
 										{@const resolvedIcon = fmIcon ?? customIcon}
 										{@const iconColor = fmIcon ? undefined : customEntry?.color}
+										{@const iconTextColor = fmIcon ? undefined : customEntry?.textColor}
 										{@const isActive = note.path === activePath}
 										<Tooltip.Root>
 											<Tooltip.Trigger>
 												{#snippet child({ props: tipProps })}
 													<button
 														{...tipProps}
-														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+														class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none {isActive ? 'bg-primary/25' : ''}"
+														style="padding-left: 40px;"
 														onclick={() => openFileInEditor(note.path)}
 														oncontextmenu={() => { contextTarget = note; sectionContextPath = null; }}
 													>
 														{#if resolvedIcon}
-															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
+															<IconRenderer icon={resolvedIcon} class="size-4 shrink-0" color={iconColor} />
+														{:else}
+															<FileText class="size-3.5 shrink-0 text-muted-foreground" />
 														{/if}
-														<span class="truncate">{note.title}</span>
+														<span class="truncate {isActive ? 'text-primary' : ''}" style:color={!isActive && iconTextColor ? iconTextColor : undefined}>{note.title}</span>
 													</button>
 												{/snippet}
 											</Tooltip.Trigger>
@@ -229,16 +233,15 @@
 						{@const untypedCollapsed = collapsedSections.has('__untyped')}
 						<div class="mb-1 mt-2 border-t border-border pt-1">
 							<button
-								class="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-accent transition-colors cursor-pointer"
+								class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none"
 								onclick={() => toggleSection('__untyped')}
 							>
-								<ChevronRight class="size-3 shrink-0 transition-transform {untypedCollapsed ? '' : 'rotate-90'}" />
-								<FileText class="size-3.5 shrink-0" />
+								<ChevronRight class="size-3.5 shrink-0 text-muted-foreground transition-transform {untypedCollapsed ? '' : 'rotate-90'}" />
 								<span>Untyped</span>
-								<span class="ml-auto text-xs">{untyped.length}</span>
+								<span class="ml-auto shrink-0 pr-1 text-xs text-[#8a8faa]">{untyped.length}</span>
 							</button>
 							{#if !untypedCollapsed}
-								<div class="pl-4">
+								<div>
 									{#each untyped as note (note.path)}
 										{@const customEntry = fileIconsStore.getIcon(note.path)}
 										{@const fmRef = fileIconsStore.getFrontmatterIcon(note.path)}
@@ -246,20 +249,24 @@
 										{@const fmIcon = fmRef ? getIconSync(fmRef.iconPack, fmRef.iconName) : undefined}
 										{@const resolvedIcon = fmIcon ?? customIcon}
 										{@const iconColor = fmIcon ? undefined : customEntry?.color}
+										{@const iconTextColor = fmIcon ? undefined : customEntry?.textColor}
 										{@const isActive = note.path === activePath}
 										<Tooltip.Root>
 											<Tooltip.Trigger>
 												{#snippet child({ props: tipProps })}
 													<button
 														{...tipProps}
-														class="flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-sm transition-colors truncate cursor-pointer {isActive ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+														class="flex w-full items-center gap-1 rounded px-2 py-[5px] text-[15px] hover:bg-primary/10 hover:text-primary cursor-default select-none {isActive ? 'bg-primary/25' : ''}"
+														style="padding-left: 40px;"
 														onclick={() => openFileInEditor(note.path)}
 														oncontextmenu={() => { contextTarget = note; sectionContextPath = null; }}
 													>
 														{#if resolvedIcon}
-															<IconRenderer icon={resolvedIcon} class="size-3.5 shrink-0" color={iconColor} />
+															<IconRenderer icon={resolvedIcon} class="size-4 shrink-0" color={iconColor} />
+														{:else}
+															<FileText class="size-3.5 shrink-0 text-muted-foreground" />
 														{/if}
-														<span class="truncate">{note.title}</span>
+														<span class="truncate {isActive ? 'text-primary' : ''}" style:color={!isActive && iconTextColor ? iconTextColor : undefined}>{note.title}</span>
 													</button>
 												{/snippet}
 											</Tooltip.Trigger>

--- a/src/lib/features/type-definitions/inbox-workflow.logic.ts
+++ b/src/lib/features/type-definitions/inbox-workflow.logic.ts
@@ -1,0 +1,37 @@
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+
+/**
+ * Returns whether the inbox filter should be active based on the
+ * explicitOrganization setting.
+ */
+export function isInboxEnabled(explicitOrganization: boolean): boolean {
+	return explicitOrganization;
+}
+
+/**
+ * Returns entries that belong in the inbox:
+ * not organized, not archived, not a Type Definition.
+ */
+export function getInboxEntries(entries: NoteEntryV2[]): NoteEntryV2[] {
+	return entries.filter((e) => !e.organized && !e.archived && e.isA !== 'Type');
+}
+
+/**
+ * Returns the inbox count.
+ */
+export function getInboxCount(entries: NoteEntryV2[]): number {
+	let count = 0;
+	for (const e of entries) {
+		if (!e.organized && !e.archived && e.isA !== 'Type') count++;
+	}
+	return count;
+}
+
+/**
+ * Determines if a newly created note should start unorganized.
+ * When explicitOrganization is enabled, new notes start unorganized.
+ * When disabled, new notes are treated as organized by default (no inbox concept).
+ */
+export function shouldNewNoteBeUnorganized(explicitOrganization: boolean): boolean {
+	return explicitOrganization;
+}

--- a/src/lib/features/type-definitions/type-definitions.logic.ts
+++ b/src/lib/features/type-definitions/type-definitions.logic.ts
@@ -1,0 +1,124 @@
+import type { NoteEntryV2, FrontmatterValue } from '$lib/types/vault-v2.types';
+
+/** Display metadata for a type definition. */
+export interface TypeMetadata {
+	/** Type name (from entry title, e.g. "Project"). */
+	name: string;
+	/** Display icon name (lucide). */
+	icon: string;
+	/** Display color. */
+	color: string;
+	/** Sort order for sidebar sections. Lower = higher. */
+	order: number;
+	/** Sidebar label override (defaults to name + "s"). */
+	sidebarLabel: string;
+	/** Template path or content for new notes of this type. */
+	template: string | null;
+	/** Default sort field for notes of this type. */
+	sort: string;
+	/** Default view mode. */
+	view: string;
+	/** Whether the type section is visible in the sidebar. */
+	visible: boolean;
+	/** Properties to display in list views. */
+	listPropertiesDisplay: string[];
+}
+
+/** Built-in fallback metadata for common types. */
+const BUILTIN_TYPES: Record<string, Partial<TypeMetadata>> = {
+	Project: { icon: 'rocket', color: 'red', order: 1 },
+	Person: { icon: 'users', color: 'blue', order: 2 },
+	Event: { icon: 'calendar', color: 'purple', order: 3 },
+	Topic: { icon: 'tag', color: 'green', order: 4 },
+	Task: { icon: 'check-square', color: 'orange', order: 5 },
+	Note: { icon: 'file-text', color: 'gray', order: 99 },
+};
+
+/** Default metadata values. */
+const DEFAULTS: TypeMetadata = {
+	name: '',
+	icon: 'file-text',
+	color: 'gray',
+	order: 50,
+	sidebarLabel: '',
+	template: null,
+	sort: 'title',
+	view: 'all',
+	visible: true,
+	listPropertiesDisplay: [],
+};
+
+/** Extracts a string from a frontmatter value. */
+function fmString(fm: Record<string, FrontmatterValue>, key: string): string | null {
+	const v = fm[key];
+	return typeof v === 'string' ? v : null;
+}
+
+/** Extracts a number from a frontmatter value. */
+function fmNumber(fm: Record<string, FrontmatterValue>, key: string): number | null {
+	const v = fm[key];
+	return typeof v === 'number' ? v : null;
+}
+
+/** Extracts a boolean from a frontmatter value. */
+function fmBool(fm: Record<string, FrontmatterValue>, key: string): boolean | null {
+	const v = fm[key];
+	return typeof v === 'boolean' ? v : null;
+}
+
+/** Extracts a string array from a frontmatter value. */
+function fmStringArray(fm: Record<string, FrontmatterValue>, key: string): string[] | null {
+	const v = fm[key];
+	if (!Array.isArray(v)) return null;
+	return v.filter((item): item is string => typeof item === 'string');
+}
+
+/** Returns true if the entry is a Type Definition (is_a === "Type"). */
+export function isTypeDefinition(entry: NoteEntryV2): boolean {
+	return entry.isA === 'Type';
+}
+
+/** Extracts TypeMetadata from a Type Definition entry. */
+export function extractTypeMetadata(entry: NoteEntryV2): TypeMetadata {
+	const fm = entry.frontmatter;
+	const name = entry.title;
+	const builtin = BUILTIN_TYPES[name] ?? {};
+
+	return {
+		name,
+		icon: fmString(fm, '_icon') ?? builtin.icon ?? DEFAULTS.icon,
+		color: fmString(fm, '_color') ?? builtin.color ?? DEFAULTS.color,
+		order: fmNumber(fm, '_order') ?? builtin.order ?? DEFAULTS.order,
+		sidebarLabel: fmString(fm, '_sidebar_label') ?? `${name}s`,
+		template: fmString(fm, '_template'),
+		sort: fmString(fm, '_sort') ?? DEFAULTS.sort,
+		view: fmString(fm, '_view') ?? DEFAULTS.view,
+		visible: fmBool(fm, '_visible') ?? DEFAULTS.visible,
+		listPropertiesDisplay: fmStringArray(fm, '_list_properties_display') ?? DEFAULTS.listPropertiesDisplay,
+	};
+}
+
+/** Builds a type metadata map from all vault entries. */
+export function buildTypeMetadataMap(entries: NoteEntryV2[]): Map<string, TypeMetadata> {
+	const map = new Map<string, TypeMetadata>();
+	for (const entry of entries) {
+		if (isTypeDefinition(entry)) {
+			const meta = extractTypeMetadata(entry);
+			map.set(meta.name, meta);
+		}
+	}
+	return map;
+}
+
+/** Returns metadata for a type name, falling back to builtins then defaults. */
+export function getTypeMetadataFallback(name: string, map: Map<string, TypeMetadata>): TypeMetadata {
+	const existing = map.get(name);
+	if (existing) return existing;
+	const builtin = BUILTIN_TYPES[name];
+	return {
+		...DEFAULTS,
+		name,
+		...(builtin ?? {}),
+		sidebarLabel: builtin ? `${name}s` : `${name}s`,
+	};
+}

--- a/src/lib/features/type-definitions/type-definitions.logic.ts
+++ b/src/lib/features/type-definitions/type-definitions.logic.ts
@@ -119,6 +119,6 @@ export function getTypeMetadataFallback(name: string, map: Map<string, TypeMetad
 		...DEFAULTS,
 		name,
 		...(builtin ?? {}),
-		sidebarLabel: builtin ? `${name}s` : `${name}s`,
+		sidebarLabel: `${name}s`,
 	};
 }

--- a/src/lib/features/type-definitions/type-definitions.service.ts
+++ b/src/lib/features/type-definitions/type-definitions.service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import { parseFrontmatterProperties, extractBody, rebuildContent, updatePropertyValue, addProperty } from '$lib/features/properties/properties.logic';
 import { buildTypeMetadataMap } from './type-definitions.logic';
 import { typeDefinitionsStore } from './type-definitions.store.svelte';
 
@@ -8,4 +10,27 @@ export async function refreshTypeDefinitions(entries?: NoteEntryV2[]): Promise<v
 	const data = entries ?? await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
 	const map = buildTypeMetadataMap(data);
 	typeDefinitionsStore.setTypeMetadataMap(map);
+}
+
+function upsertProperty(properties: ReturnType<typeof parseFrontmatterProperties>, key: string, value: string) {
+	const exists = properties.some((p) => p.key === key);
+	if (exists) return updatePropertyValue(properties, key, value, 'text');
+	return updatePropertyValue(addProperty(properties, key), key, value, 'text');
+}
+
+/** Updates _icon and _color in a type definition note's frontmatter. */
+export async function updateTypeDefinitionIcon(
+	path: string,
+	iconName: string | null,
+	color: string | null,
+): Promise<void> {
+	const content = await readTextFile(path);
+	let properties = parseFrontmatterProperties(content);
+	const body = extractBody(content);
+
+	if (iconName) properties = upsertProperty(properties, '_icon', iconName);
+	if (color) properties = upsertProperty(properties, '_color', color);
+
+	const newContent = rebuildContent(properties, body);
+	await writeTextFile(path, newContent);
 }

--- a/src/lib/features/type-definitions/type-definitions.service.ts
+++ b/src/lib/features/type-definitions/type-definitions.service.ts
@@ -1,0 +1,11 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import { buildTypeMetadataMap } from './type-definitions.logic';
+import { typeDefinitionsStore } from './type-definitions.store.svelte';
+
+/** Fetches all vault entries and rebuilds the type metadata map. */
+export async function refreshTypeDefinitions(): Promise<void> {
+	const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
+	const map = buildTypeMetadataMap(entries);
+	typeDefinitionsStore.setTypeMetadataMap(map);
+}

--- a/src/lib/features/type-definitions/type-definitions.service.ts
+++ b/src/lib/features/type-definitions/type-definitions.service.ts
@@ -3,9 +3,9 @@ import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 import { buildTypeMetadataMap } from './type-definitions.logic';
 import { typeDefinitionsStore } from './type-definitions.store.svelte';
 
-/** Fetches all vault entries and rebuilds the type metadata map. */
-export async function refreshTypeDefinitions(): Promise<void> {
-	const entries = await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
-	const map = buildTypeMetadataMap(entries);
+/** Rebuilds the type metadata map. Fetches entries if not provided. */
+export async function refreshTypeDefinitions(entries?: NoteEntryV2[]): Promise<void> {
+	const data = entries ?? await invoke<NoteEntryV2[]>('get_all_vault_entries_v2');
+	const map = buildTypeMetadataMap(data);
 	typeDefinitionsStore.setTypeMetadataMap(map);
 }

--- a/src/lib/features/type-definitions/type-definitions.service.ts
+++ b/src/lib/features/type-definitions/type-definitions.service.ts
@@ -28,6 +28,8 @@ export async function updateTypeDefinitionIcon(
 	let properties = parseFrontmatterProperties(content);
 	const body = extractBody(content);
 
+	if (!iconName && !color) return;
+
 	if (iconName) properties = upsertProperty(properties, '_icon', iconName);
 	if (color) properties = upsertProperty(properties, '_color', color);
 

--- a/src/lib/features/type-definitions/type-definitions.store.svelte.ts
+++ b/src/lib/features/type-definitions/type-definitions.store.svelte.ts
@@ -1,0 +1,25 @@
+import type { TypeMetadata } from './type-definitions.logic';
+
+let typeMetadataMap = $state<Map<string, TypeMetadata>>(new Map());
+
+export const typeDefinitionsStore = {
+	get typeMetadataMap() { return typeMetadataMap; },
+
+	/** Returns metadata for a type name, or undefined if not defined. */
+	getTypeMetadata(typeName: string): TypeMetadata | undefined {
+		return typeMetadataMap.get(typeName);
+	},
+
+	/** Returns all type metadata entries sorted by order. */
+	get sortedTypes(): TypeMetadata[] {
+		return Array.from(typeMetadataMap.values()).sort((a, b) => a.order - b.order);
+	},
+
+	setTypeMetadataMap(map: Map<string, TypeMetadata>): void {
+		typeMetadataMap = map;
+	},
+
+	reset(): void {
+		typeMetadataMap = new Map();
+	},
+};

--- a/src/lib/features/type-definitions/type-definitions.store.svelte.ts
+++ b/src/lib/features/type-definitions/type-definitions.store.svelte.ts
@@ -1,9 +1,14 @@
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 import type { TypeMetadata } from './type-definitions.logic';
 
 let typeMetadataMap = $state<Map<string, TypeMetadata>>(new Map());
+let entries = $state<NoteEntryV2[]>([]);
+let entriesVersion = $state(0);
 
 export const typeDefinitionsStore = {
 	get typeMetadataMap() { return typeMetadataMap; },
+	get entries() { return entries; },
+	get entriesVersion() { return entriesVersion; },
 
 	/** Returns metadata for a type name, or undefined if not defined. */
 	getTypeMetadata(typeName: string): TypeMetadata | undefined {
@@ -19,7 +24,15 @@ export const typeDefinitionsStore = {
 		typeMetadataMap = map;
 	},
 
+	/** Stores the latest vault entries snapshot for sidebar consumption. */
+	setEntries(value: NoteEntryV2[]): void {
+		entries = value;
+		entriesVersion++;
+	},
+
 	reset(): void {
 		typeMetadataMap = new Map();
+		entries = [];
+		entriesVersion = 0;
 	},
 };

--- a/src/lib/features/type-definitions/type-sidebar.logic.ts
+++ b/src/lib/features/type-definitions/type-sidebar.logic.ts
@@ -6,6 +6,8 @@ import { getTypeMetadataFallback } from './type-definitions.logic';
 export interface TypeSection {
 	/** Type metadata (icon, color, order, label). */
 	metadata: TypeMetadata;
+	/** Path to the type definition note (if it exists). */
+	definitionPath: string | null;
 	/** Notes of this type, sorted. */
 	notes: TypeSidebarNote[];
 }
@@ -27,7 +29,12 @@ export function buildTypeSections(
 ): { sections: TypeSection[]; untyped: TypeSidebarNote[] } {
 	const filtered = applyFilter(entries, filter);
 	const typeGroups = new Map<string, TypeSidebarNote[]>();
+	const typeDefPaths = new Map<string, string>();
 	const untyped: TypeSidebarNote[] = [];
+
+	for (const entry of entries) {
+		if (entry.isA === 'Type') typeDefPaths.set(entry.title, entry.path);
+	}
 
 	for (const entry of filtered) {
 		if (entry.isA === 'Type') continue;
@@ -49,7 +56,7 @@ export function buildTypeSections(
 		const metadata = getTypeMetadataFallback(typeName, typeMetadataMap);
 		if (!metadata.visible) continue;
 		notes.sort((a, b) => a.title.localeCompare(b.title));
-		sections.push({ metadata, notes });
+		sections.push({ metadata, definitionPath: typeDefPaths.get(typeName) ?? null, notes });
 	}
 
 	sections.sort((a, b) => a.metadata.order - b.metadata.order);

--- a/src/lib/features/type-definitions/type-sidebar.logic.ts
+++ b/src/lib/features/type-definitions/type-sidebar.logic.ts
@@ -1,0 +1,86 @@
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import type { TypeMetadata } from './type-definitions.logic';
+import { getTypeMetadataFallback } from './type-definitions.logic';
+
+/** A section in the type-grouped sidebar. */
+export interface TypeSection {
+	/** Type metadata (icon, color, order, label). */
+	metadata: TypeMetadata;
+	/** Notes of this type, sorted. */
+	notes: TypeSidebarNote[];
+}
+
+/** A note entry in the type sidebar. */
+export interface TypeSidebarNote {
+	path: string;
+	title: string;
+}
+
+/** Filter mode for the type sidebar. */
+export type SidebarFilter = 'all' | 'inbox' | 'archived' | 'favorites';
+
+/** Builds type-grouped sections from vault entries. */
+export function buildTypeSections(
+	entries: NoteEntryV2[],
+	typeMetadataMap: Map<string, TypeMetadata>,
+	filter: SidebarFilter,
+): { sections: TypeSection[]; untyped: TypeSidebarNote[] } {
+	const filtered = applyFilter(entries, filter);
+	const typeGroups = new Map<string, TypeSidebarNote[]>();
+	const untyped: TypeSidebarNote[] = [];
+
+	for (const entry of filtered) {
+		if (entry.isA === 'Type') continue;
+		const note: TypeSidebarNote = { path: entry.path, title: entry.title };
+		if (entry.isA) {
+			const group = typeGroups.get(entry.isA);
+			if (group) {
+				group.push(note);
+			} else {
+				typeGroups.set(entry.isA, [note]);
+			}
+		} else {
+			untyped.push(note);
+		}
+	}
+
+	const sections: TypeSection[] = [];
+	for (const [typeName, notes] of typeGroups) {
+		const metadata = getTypeMetadataFallback(typeName, typeMetadataMap);
+		if (!metadata.visible) continue;
+		const sortField = metadata.sort;
+		notes.sort((a, b) => {
+			if (sortField === 'title') return a.title.localeCompare(b.title);
+			return a.title.localeCompare(b.title);
+		});
+		sections.push({ metadata, notes });
+	}
+
+	sections.sort((a, b) => a.metadata.order - b.metadata.order);
+	untyped.sort((a, b) => a.title.localeCompare(b.title));
+
+	return { sections, untyped };
+}
+
+/** Applies the sidebar filter to entries. */
+function applyFilter(entries: NoteEntryV2[], filter: SidebarFilter): NoteEntryV2[] {
+	switch (filter) {
+		case 'all':
+			return entries.filter((e) => !e.archived);
+		case 'inbox':
+			return entries.filter((e) => !e.organized && !e.archived);
+		case 'archived':
+			return entries.filter((e) => e.archived);
+		case 'favorites':
+			return entries.filter((e) => e.favorite && !e.archived);
+	}
+}
+
+/** Returns the inbox count (not organized, not archived). */
+export function countInbox(entries: NoteEntryV2[]): number {
+	let count = 0;
+	for (const e of entries) {
+		if (!e.organized && !e.archived && e.isA !== 'Type') count++;
+	}
+	return count;
+}

--- a/src/lib/features/type-definitions/type-sidebar.logic.ts
+++ b/src/lib/features/type-definitions/type-sidebar.logic.ts
@@ -48,11 +48,7 @@ export function buildTypeSections(
 	for (const [typeName, notes] of typeGroups) {
 		const metadata = getTypeMetadataFallback(typeName, typeMetadataMap);
 		if (!metadata.visible) continue;
-		const sortField = metadata.sort;
-		notes.sort((a, b) => {
-			if (sortField === 'title') return a.title.localeCompare(b.title);
-			return a.title.localeCompare(b.title);
-		});
+		notes.sort((a, b) => a.title.localeCompare(b.title));
 		sections.push({ metadata, notes });
 	}
 

--- a/src/lib/features/type-definitions/type-sidebar.logic.ts
+++ b/src/lib/features/type-definitions/type-sidebar.logic.ts
@@ -52,11 +52,18 @@ export function buildTypeSections(
 	}
 
 	const sections: TypeSection[] = [];
+	const seen = new Set<string>();
 	for (const [typeName, notes] of typeGroups) {
 		const metadata = getTypeMetadataFallback(typeName, typeMetadataMap);
 		if (!metadata.visible) continue;
 		notes.sort((a, b) => a.title.localeCompare(b.title));
 		sections.push({ metadata, definitionPath: typeDefPaths.get(typeName) ?? null, notes });
+		seen.add(typeName);
+	}
+
+	for (const [typeName, metadata] of typeMetadataMap) {
+		if (seen.has(typeName) || !metadata.visible) continue;
+		sections.push({ metadata, definitionPath: typeDefPaths.get(typeName) ?? null, notes: [] });
 	}
 
 	sections.sort((a, b) => a.metadata.order - b.metadata.order);

--- a/src/lib/types/vault-v2.types.ts
+++ b/src/lib/types/vault-v2.types.ts
@@ -131,6 +131,21 @@ export interface NoteEntryV2 {
 }
 
 /**
+ * A backlink from a frontmatter relationship field.
+ * Returned by `invoke('get_relationship_backlinks_v2', { path })`.
+ *
+ * @experimental
+ */
+export interface RelationshipBacklinkV2 {
+	/** Absolute path of the source note. */
+	sourcePath: string;
+	/** Title of the source note. */
+	sourceName: string;
+	/** Relationship type (e.g. "belongs_to", "related_to", or custom field name). */
+	relationshipType: string;
+}
+
+/**
  * One outgoing wikilink already resolved by the Rust `VaultIndex` —
  * returned by `invoke('get_outgoing_links_v2', { path })`. Mirrors
  * `kokobrain_lib::vault::entry::OutgoingLink` and the legacy TS

--- a/src/lib/types/vault-v2.types.ts
+++ b/src/lib/types/vault-v2.types.ts
@@ -122,6 +122,12 @@ export interface NoteEntryV2 {
 	archived: boolean;
 	/** Lifecycle flag: note is pinned as a favorite. */
 	favorite: boolean;
+	/** Hierarchical ownership targets from `belongs_to` frontmatter (wikilink targets). */
+	belongsTo: string[];
+	/** Lateral relationship targets from `related_to` frontmatter (wikilink targets). */
+	relatedTo: string[];
+	/** Generic relationships: field name -> wikilink targets for fields containing `[[...]]`. */
+	relationships: Record<string, string[]>;
 }
 
 /**

--- a/src/lib/types/vault-v2.types.ts
+++ b/src/lib/types/vault-v2.types.ts
@@ -114,6 +114,8 @@ export interface NoteEntryV2 {
 	snippet: string;
 	/** Markdown task list items in document order. Phase 7. */
 	tasks: TaskV2[];
+	/** Document type from `type` frontmatter key (alias-resolved, casing normalized). `null` when absent. */
+	isA: string | null;
 }
 
 /**

--- a/src/lib/types/vault-v2.types.ts
+++ b/src/lib/types/vault-v2.types.ts
@@ -116,6 +116,12 @@ export interface NoteEntryV2 {
 	tasks: TaskV2[];
 	/** Document type from `type` frontmatter key (alias-resolved, casing normalized). `null` when absent. */
 	isA: string | null;
+	/** Lifecycle flag: note has been explicitly organized. */
+	organized: boolean;
+	/** Lifecycle flag: note is archived (hidden from default views). */
+	archived: boolean;
+	/** Lifecycle flag: note is pinned as a favorite. */
+	favorite: boolean;
 }
 
 /**

--- a/src/lib/utils/frontmatter-aliases.ts
+++ b/src/lib/utils/frontmatter-aliases.ts
@@ -1,0 +1,32 @@
+/**
+ * Frontmatter key alias resolution.
+ * Maps alternative spellings of system metadata keys to their canonical form.
+ */
+
+const ALIAS_MAP: ReadonlyMap<string, string> = new Map([
+	['is_a', 'type'],
+	['is a', 'type'],
+	['belongs to', 'belongs_to'],
+	['related to', 'related_to'],
+	['organized', '_organized'],
+	['archived', '_archived'],
+	['favorite', '_favorite'],
+	['order', '_order'],
+	['sort', '_sort'],
+	['icon', '_icon'],
+	['sidebar_label', '_sidebar_label'],
+	['sidebar label', '_sidebar_label'],
+	['color', '_color'],
+	['template', '_template'],
+	['view', '_view'],
+	['visible', '_visible'],
+	['list_properties_display', '_list_properties_display'],
+]);
+
+/**
+ * Returns the canonical key name if the input matches a known alias,
+ * otherwise returns the input unchanged.
+ */
+export function canonicalizeKey(key: string): string {
+	return ALIAS_MAP.get(key) ?? key;
+}

--- a/src/tests/fixtures/vault-entries.fixture.ts
+++ b/src/tests/fixtures/vault-entries.fixture.ts
@@ -30,6 +30,9 @@ export function entryV2(
 		snippet: '',
 		tasks: [],
 		isA: null,
+		organized: false,
+		archived: false,
+		favorite: false,
 		...overrides,
 	};
 }

--- a/src/tests/fixtures/vault-entries.fixture.ts
+++ b/src/tests/fixtures/vault-entries.fixture.ts
@@ -33,6 +33,9 @@ export function entryV2(
 		organized: false,
 		archived: false,
 		favorite: false,
+		belongsTo: [],
+		relatedTo: [],
+		relationships: {},
 		...overrides,
 	};
 }

--- a/src/tests/fixtures/vault-entries.fixture.ts
+++ b/src/tests/fixtures/vault-entries.fixture.ts
@@ -29,6 +29,7 @@ export function entryV2(
 		wordCount: 0,
 		snippet: '',
 		tasks: [],
+		isA: null,
 		...overrides,
 	};
 }

--- a/src/tests/lib/core/filesystem/link-updater.service.test.ts
+++ b/src/tests/lib/core/filesystem/link-updater.service.test.ts
@@ -35,6 +35,7 @@ function entry(path: string, title?: string): NoteEntryV2 {
 		wordCount: 0,
 		snippet: '',
 		tasks: [],
+		isA: null,
 	};
 }
 

--- a/src/tests/lib/core/filesystem/link-updater.service.test.ts
+++ b/src/tests/lib/core/filesystem/link-updater.service.test.ts
@@ -39,6 +39,9 @@ function entry(path: string, title?: string): NoteEntryV2 {
 		organized: false,
 		archived: false,
 		favorite: false,
+		belongsTo: [],
+		relatedTo: [],
+		relationships: {},
 	};
 }
 

--- a/src/tests/lib/core/filesystem/link-updater.service.test.ts
+++ b/src/tests/lib/core/filesystem/link-updater.service.test.ts
@@ -36,6 +36,9 @@ function entry(path: string, title?: string): NoteEntryV2 {
 		snippet: '',
 		tasks: [],
 		isA: null,
+		organized: false,
+		archived: false,
+		favorite: false,
 	};
 }
 

--- a/src/tests/lib/core/settings/settings.logic.test.ts
+++ b/src/tests/lib/core/settings/settings.logic.test.ts
@@ -243,7 +243,7 @@ describe('SETTINGS_SECTION_GROUPS', () => {
 
 	it('contains all expected sections in order', () => {
 		const ids = SETTINGS_SECTION_GROUPS.flatMap((g) => g.sections.map((s) => s.id));
-		expect(ids).toEqual(['appearance', 'editor', 'sidebar', 'periodic-notes', 'quick-note', 'one-on-one', 'templates', 'search', 'file-history', 'auto-move', 'trash', 'terminal', 'queryjs', 'todoist', 'troubleshooting', 'update']);
+		expect(ids).toEqual(['appearance', 'editor', 'sidebar', 'periodic-notes', 'quick-note', 'one-on-one', 'templates', 'types', 'search', 'file-history', 'auto-move', 'trash', 'terminal', 'queryjs', 'todoist', 'troubleshooting', 'update']);
 	});
 
 	it('has labels for every section', () => {

--- a/src/tests/lib/features/backlinks/backlinks.logic.test.ts
+++ b/src/tests/lib/features/backlinks/backlinks.logic.test.ts
@@ -189,6 +189,7 @@ describe('noteEntryV2ToBacklinkEntry', () => {
 			wordCount: 0,
 			snippet: '',
 			tasks: [],
+			isA: null,
 			...overrides,
 		};
 	}

--- a/src/tests/lib/features/backlinks/backlinks.logic.test.ts
+++ b/src/tests/lib/features/backlinks/backlinks.logic.test.ts
@@ -193,6 +193,9 @@ describe('noteEntryV2ToBacklinkEntry', () => {
 			organized: false,
 			archived: false,
 			favorite: false,
+			belongsTo: [],
+			relatedTo: [],
+			relationships: {},
 			...overrides,
 		};
 	}

--- a/src/tests/lib/features/backlinks/backlinks.logic.test.ts
+++ b/src/tests/lib/features/backlinks/backlinks.logic.test.ts
@@ -190,6 +190,9 @@ describe('noteEntryV2ToBacklinkEntry', () => {
 			snippet: '',
 			tasks: [],
 			isA: null,
+			organized: false,
+			archived: false,
+			favorite: false,
 			...overrides,
 		};
 	}

--- a/src/tests/lib/features/collection/portent-filters.test.ts
+++ b/src/tests/lib/features/collection/portent-filters.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { executeQuery } from '$lib/features/collection/collection.logic';
+import type { CollectionDefinition, CollectionViewDef, NoteRecord } from '$lib/features/collection/collection.types';
+
+function makeRecord(path: string, props: Record<string, unknown>): NoteRecord {
+	const name = path.split('/').pop() ?? path;
+	const ext = '.md';
+	const basename = name.replace('.md', '');
+	const folder = path.substring(0, path.lastIndexOf('/'));
+	return {
+		path, name, basename, folder, ext,
+		mtime: 0, ctime: 0, size: 0,
+		properties: new Map(Object.entries(props)),
+	};
+}
+
+function makeIndex(records: NoteRecord[]): Map<string, NoteRecord> {
+	return new Map(records.map((r) => [r.path, r]));
+}
+
+function baseDef(filters: unknown): CollectionDefinition {
+	return { filters } as CollectionDefinition;
+}
+
+function baseView(overrides: Partial<CollectionViewDef> = {}): CollectionViewDef {
+	return { type: 'table', name: 'Test', ...overrides };
+}
+
+describe('Portent collection filters', () => {
+	it('filters by type equals', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { type: 'Project' }),
+			makeRecord('/b.md', { type: 'Person' }),
+			makeRecord('/c.md', {}),
+		]);
+		const def = baseDef("type == 'Project'");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+
+	it('filters by organized boolean', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { organized: true }),
+			makeRecord('/b.md', { organized: false }),
+		]);
+		const def = baseDef("organized == true");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+
+	it('filters by archived boolean', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { archived: false }),
+			makeRecord('/b.md', { archived: true }),
+		]);
+		const def = baseDef("archived == true");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/b.md']);
+	});
+
+	it('filters by favorite boolean', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { favorite: true }),
+			makeRecord('/b.md', { favorite: false }),
+		]);
+		const def = baseDef("favorite == true");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+
+	it('filters by belongs_to contains', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { belongs_to: ['project', 'area'] }),
+			makeRecord('/b.md', { belongs_to: ['other'] }),
+			makeRecord('/c.md', {}),
+		]);
+		const def = baseDef("belongs_to.contains('project')");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+
+	it('filters by related_to contains', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { related_to: ['maps'] }),
+			makeRecord('/b.md', {}),
+		]);
+		const def = baseDef("related_to.contains('maps')");
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+
+	it('combines type and archived filters', () => {
+		const index = makeIndex([
+			makeRecord('/a.md', { type: 'Project', archived: false }),
+			makeRecord('/b.md', { type: 'Project', archived: true }),
+			makeRecord('/c.md', { type: 'Person', archived: false }),
+		]);
+		const def = baseDef({ and: ["type == 'Project'", "archived == false"] });
+		const result = executeQuery(def, baseView(), index);
+		expect(result.records.map((r) => r.path)).toEqual(['/a.md']);
+	});
+});

--- a/src/tests/lib/features/properties/lifecycle-filter.logic.test.ts
+++ b/src/tests/lib/features/properties/lifecycle-filter.logic.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+	excludeArchived,
+	onlyArchived,
+	buildArchivedPathSet,
+	countArchived,
+} from '$lib/features/properties/lifecycle-filter.logic';
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+
+function entry(path: string, archived: boolean): NoteEntryV2 {
+	return {
+		path,
+		title: path.split('/').pop()?.replace('.md', '') ?? path,
+		frontmatter: {},
+		outgoingLinks: [],
+		tags: [],
+		modifiedAt: 0,
+		createdAt: 0,
+		size: 0,
+		wordCount: 0,
+		snippet: '',
+		tasks: [],
+		isA: null,
+		organized: false,
+		archived,
+		favorite: false,
+	};
+}
+
+describe('excludeArchived', () => {
+	it('removes archived entries', () => {
+		const entries = [entry('/a.md', false), entry('/b.md', true), entry('/c.md', false)];
+		const result = excludeArchived(entries);
+		expect(result.map((e) => e.path)).toEqual(['/a.md', '/c.md']);
+	});
+
+	it('returns all when none archived', () => {
+		const entries = [entry('/a.md', false), entry('/b.md', false)];
+		expect(excludeArchived(entries)).toHaveLength(2);
+	});
+
+	it('returns empty when all archived', () => {
+		const entries = [entry('/a.md', true), entry('/b.md', true)];
+		expect(excludeArchived(entries)).toHaveLength(0);
+	});
+});
+
+describe('onlyArchived', () => {
+	it('returns only archived entries', () => {
+		const entries = [entry('/a.md', false), entry('/b.md', true), entry('/c.md', true)];
+		const result = onlyArchived(entries);
+		expect(result.map((e) => e.path)).toEqual(['/b.md', '/c.md']);
+	});
+});
+
+describe('buildArchivedPathSet', () => {
+	it('builds set of archived paths', () => {
+		const entries = [entry('/a.md', false), entry('/b.md', true), entry('/c.md', true)];
+		const set = buildArchivedPathSet(entries);
+		expect(set.has('/b.md')).toBe(true);
+		expect(set.has('/c.md')).toBe(true);
+		expect(set.has('/a.md')).toBe(false);
+	});
+
+	it('returns empty set when no archived', () => {
+		const entries = [entry('/a.md', false)];
+		expect(buildArchivedPathSet(entries).size).toBe(0);
+	});
+});
+
+describe('countArchived', () => {
+	it('counts archived entries', () => {
+		const entries = [entry('/a.md', false), entry('/b.md', true), entry('/c.md', true)];
+		expect(countArchived(entries)).toBe(2);
+	});
+
+	it('returns 0 when none archived', () => {
+		expect(countArchived([entry('/a.md', false)])).toBe(0);
+	});
+});

--- a/src/tests/lib/features/properties/lifecycle-filter.logic.test.ts
+++ b/src/tests/lib/features/properties/lifecycle-filter.logic.test.ts
@@ -24,6 +24,9 @@ function entry(path: string, archived: boolean): NoteEntryV2 {
 		organized: false,
 		archived,
 		favorite: false,
+		belongsTo: [],
+		relatedTo: [],
+		relationships: {},
 	};
 }
 

--- a/src/tests/lib/features/properties/lifecycle.logic.test.ts
+++ b/src/tests/lib/features/properties/lifecycle.logic.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+	getLifecycleState,
+	isFavorite,
+	setBooleanFlag,
+	removeBooleanFlag,
+	toggleOrganized,
+	toggleArchived,
+	toggleFavorite,
+} from '$lib/features/properties/lifecycle.logic';
+import type { Property } from '$lib/features/properties/properties.types';
+
+function prop(key: string, value: unknown): Property {
+	return { key, value, type: typeof value === 'boolean' ? 'boolean' : 'text' } as Property;
+}
+
+describe('getLifecycleState', () => {
+	it('returns inbox when no flags', () => {
+		expect(getLifecycleState([])).toBe('inbox');
+		expect(getLifecycleState([prop('title', 'Hello')])).toBe('inbox');
+	});
+
+	it('returns organized when _organized true', () => {
+		expect(getLifecycleState([prop('_organized', true)])).toBe('organized');
+	});
+
+	it('returns archived when _archived true (overrides organized)', () => {
+		expect(getLifecycleState([prop('_organized', true), prop('_archived', true)])).toBe('archived');
+	});
+
+	it('returns inbox when _organized false', () => {
+		expect(getLifecycleState([prop('_organized', false)])).toBe('inbox');
+	});
+});
+
+describe('isFavorite', () => {
+	it('returns false when no _favorite', () => {
+		expect(isFavorite([])).toBe(false);
+	});
+
+	it('returns true when _favorite is true', () => {
+		expect(isFavorite([prop('_favorite', true)])).toBe(true);
+	});
+
+	it('returns false when _favorite is false', () => {
+		expect(isFavorite([prop('_favorite', false)])).toBe(false);
+	});
+});
+
+describe('setBooleanFlag', () => {
+	it('adds flag when not present', () => {
+		const result = setBooleanFlag([], '_organized', true);
+		expect(result).toEqual([{ key: '_organized', value: true, type: 'boolean' }]);
+	});
+
+	it('updates existing flag', () => {
+		const props = [prop('_organized', false)];
+		const result = setBooleanFlag(props, '_organized', true);
+		expect(result[0].value).toBe(true);
+	});
+
+	it('does not mutate original', () => {
+		const props = [prop('_organized', false)];
+		setBooleanFlag(props, '_organized', true);
+		expect(props[0].value).toBe(false);
+	});
+});
+
+describe('removeBooleanFlag', () => {
+	it('removes existing flag', () => {
+		const props = [prop('title', 'Hi'), prop('_archived', true)];
+		const result = removeBooleanFlag(props, '_archived');
+		expect(result.length).toBe(1);
+		expect(result[0].key).toBe('title');
+	});
+
+	it('no-op when flag absent', () => {
+		const props = [prop('title', 'Hi')];
+		const result = removeBooleanFlag(props, '_archived');
+		expect(result.length).toBe(1);
+	});
+});
+
+describe('toggleOrganized', () => {
+	it('sets _organized to true', () => {
+		const result = toggleOrganized([], true);
+		expect(result.find((p) => p.key === '_organized')?.value).toBe(true);
+	});
+
+	it('removes _archived when organizing', () => {
+		const props = [prop('_archived', true)];
+		const result = toggleOrganized(props, true);
+		expect(result.find((p) => p.key === '_archived')).toBeUndefined();
+		expect(result.find((p) => p.key === '_organized')?.value).toBe(true);
+	});
+
+	it('sets _organized to false', () => {
+		const props = [prop('_organized', true)];
+		const result = toggleOrganized(props, false);
+		expect(result.find((p) => p.key === '_organized')?.value).toBe(false);
+	});
+});
+
+describe('toggleArchived', () => {
+	it('sets _archived to true', () => {
+		const result = toggleArchived([], true);
+		expect(result.find((p) => p.key === '_archived')?.value).toBe(true);
+	});
+
+	it('sets _archived to false', () => {
+		const props = [prop('_archived', true)];
+		const result = toggleArchived(props, false);
+		expect(result.find((p) => p.key === '_archived')?.value).toBe(false);
+	});
+});
+
+describe('toggleFavorite', () => {
+	it('sets _favorite to true', () => {
+		const result = toggleFavorite([], true);
+		expect(result.find((p) => p.key === '_favorite')?.value).toBe(true);
+	});
+
+	it('sets _favorite to false', () => {
+		const props = [prop('_favorite', true)];
+		const result = toggleFavorite(props, false);
+		expect(result.find((p) => p.key === '_favorite')?.value).toBe(false);
+	});
+});

--- a/src/tests/lib/features/properties/properties.logic.test.ts
+++ b/src/tests/lib/features/properties/properties.logic.test.ts
@@ -561,3 +561,40 @@ describe('round-trip: parse → serialize → rebuild', () => {
 		expect(reparsed[2]).toEqual({ key: 'tags', value: ['a', 'b'], type: 'list' });
 	});
 });
+
+describe('frontmatter alias normalization', () => {
+	it('normalizes is_a to type', () => {
+		const content = '---\nis_a: person\n---\n';
+		const props = parseFrontmatterProperties(content);
+		expect(props[0]).toEqual({ key: 'type', value: 'person', type: 'text' });
+	});
+
+	it('normalizes space-separated aliases', () => {
+		const content = '---\nis a: place\nbelongs to: geography\n---\n';
+		const props = parseFrontmatterProperties(content);
+		expect(props.find((p) => p.key === 'type')?.value).toBe('place');
+		expect(props.find((p) => p.key === 'belongs_to')?.value).toBe('geography');
+	});
+
+	it('normalizes underscore-prefixed system keys', () => {
+		const content = '---\nicon: rocket\nfavorite: true\norder: 5\n---\n';
+		const props = parseFrontmatterProperties(content);
+		expect(props.find((p) => p.key === '_icon')?.value).toBe('rocket');
+		expect(props.find((p) => p.key === '_favorite')?.value).toBe(true);
+		expect(props.find((p) => p.key === '_order')?.value).toBe(5);
+	});
+
+	it('leaves non-aliased keys unchanged', () => {
+		const content = '---\ntitle: Hello\ntags: [a, b]\n---\n';
+		const props = parseFrontmatterProperties(content);
+		expect(props[0].key).toBe('title');
+		expect(props[1].key).toBe('tags');
+	});
+
+	it('leaves already-canonical keys unchanged', () => {
+		const content = '---\n_icon: star\ntype: note\n---\n';
+		const props = parseFrontmatterProperties(content);
+		expect(props.find((p) => p.key === '_icon')?.value).toBe('star');
+		expect(props.find((p) => p.key === 'type')?.value).toBe('note');
+	});
+});

--- a/src/tests/lib/features/type-definitions/inbox-workflow.logic.test.ts
+++ b/src/tests/lib/features/type-definitions/inbox-workflow.logic.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isInboxEnabled,
+	getInboxEntries,
+	getInboxCount,
+	shouldNewNoteBeUnorganized,
+} from '$lib/features/type-definitions/inbox-workflow.logic';
+import { entryV2 } from '../../../fixtures/vault-entries.fixture';
+
+describe('isInboxEnabled', () => {
+	it('returns true when explicitOrganization enabled', () => {
+		expect(isInboxEnabled(true)).toBe(true);
+	});
+
+	it('returns false when explicitOrganization disabled', () => {
+		expect(isInboxEnabled(false)).toBe(false);
+	});
+});
+
+describe('getInboxEntries', () => {
+	it('returns non-organized non-archived non-Type entries', () => {
+		const entries = [
+			entryV2('/v/a.md', { organized: false, archived: false, isA: null }),
+			entryV2('/v/b.md', { organized: true, archived: false, isA: null }),
+			entryV2('/v/c.md', { organized: false, archived: true, isA: null }),
+			entryV2('/v/d.md', { organized: false, archived: false, isA: 'Type' }),
+			entryV2('/v/e.md', { organized: false, archived: false, isA: 'Project' }),
+		];
+		const inbox = getInboxEntries(entries);
+		expect(inbox.map((e) => e.path)).toEqual(['/v/a.md', '/v/e.md']);
+	});
+
+	it('returns empty when all organized', () => {
+		const entries = [
+			entryV2('/v/a.md', { organized: true, archived: false }),
+		];
+		expect(getInboxEntries(entries)).toHaveLength(0);
+	});
+});
+
+describe('getInboxCount', () => {
+	it('counts inbox entries', () => {
+		const entries = [
+			entryV2('/v/a.md', { organized: false, archived: false, isA: null }),
+			entryV2('/v/b.md', { organized: true, archived: false, isA: null }),
+			entryV2('/v/c.md', { organized: false, archived: false, isA: 'Project' }),
+		];
+		expect(getInboxCount(entries)).toBe(2);
+	});
+});
+
+describe('shouldNewNoteBeUnorganized', () => {
+	it('returns true when explicitOrganization enabled', () => {
+		expect(shouldNewNoteBeUnorganized(true)).toBe(true);
+	});
+
+	it('returns false when disabled', () => {
+		expect(shouldNewNoteBeUnorganized(false)).toBe(false);
+	});
+});

--- a/src/tests/lib/features/type-definitions/type-definitions.logic.test.ts
+++ b/src/tests/lib/features/type-definitions/type-definitions.logic.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isTypeDefinition,
+	extractTypeMetadata,
+	buildTypeMetadataMap,
+	getTypeMetadataFallback,
+} from '$lib/features/type-definitions/type-definitions.logic';
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
+import { entryV2 } from '../../../fixtures/vault-entries.fixture';
+
+function typeDefEntry(title: string, fm: Record<string, unknown> = {}): NoteEntryV2 {
+	return entryV2(`/vault/${title}.md`, {
+		title,
+		isA: 'Type',
+		frontmatter: fm as NoteEntryV2['frontmatter'],
+	});
+}
+
+describe('isTypeDefinition', () => {
+	it('returns true for is_a Type', () => {
+		expect(isTypeDefinition(entryV2('/v/x.md', { isA: 'Type' }))).toBe(true);
+	});
+
+	it('returns false for other types', () => {
+		expect(isTypeDefinition(entryV2('/v/x.md', { isA: 'Project' }))).toBe(false);
+	});
+
+	it('returns false for null is_a', () => {
+		expect(isTypeDefinition(entryV2('/v/x.md'))).toBe(false);
+	});
+});
+
+describe('extractTypeMetadata', () => {
+	it('extracts all fields from frontmatter', () => {
+		const entry = typeDefEntry('Project', {
+			_icon: 'rocket',
+			_color: 'red',
+			_order: 1,
+			_sidebar_label: 'Projects',
+			_template: 'templates/project.md',
+			_sort: 'status',
+			_view: 'board',
+			_visible: true,
+			_list_properties_display: ['status', 'due'],
+		});
+		const meta = extractTypeMetadata(entry);
+		expect(meta.name).toBe('Project');
+		expect(meta.icon).toBe('rocket');
+		expect(meta.color).toBe('red');
+		expect(meta.order).toBe(1);
+		expect(meta.sidebarLabel).toBe('Projects');
+		expect(meta.template).toBe('templates/project.md');
+		expect(meta.sort).toBe('status');
+		expect(meta.view).toBe('board');
+		expect(meta.visible).toBe(true);
+		expect(meta.listPropertiesDisplay).toEqual(['status', 'due']);
+	});
+
+	it('falls back to builtin metadata for known types', () => {
+		const entry = typeDefEntry('Project', {});
+		const meta = extractTypeMetadata(entry);
+		expect(meta.icon).toBe('rocket');
+		expect(meta.color).toBe('red');
+		expect(meta.order).toBe(1);
+	});
+
+	it('falls back to defaults for unknown types', () => {
+		const entry = typeDefEntry('CustomType', {});
+		const meta = extractTypeMetadata(entry);
+		expect(meta.icon).toBe('file-text');
+		expect(meta.color).toBe('gray');
+		expect(meta.order).toBe(50);
+		expect(meta.sidebarLabel).toBe('CustomTypes');
+	});
+
+	it('uses explicit frontmatter over builtins', () => {
+		const entry = typeDefEntry('Project', { _icon: 'star', _order: 99 });
+		const meta = extractTypeMetadata(entry);
+		expect(meta.icon).toBe('star');
+		expect(meta.order).toBe(99);
+	});
+});
+
+describe('buildTypeMetadataMap', () => {
+	it('builds map from type definition entries only', () => {
+		const entries = [
+			typeDefEntry('Project', { _icon: 'rocket' }),
+			entryV2('/vault/task.md', { isA: 'Project', title: 'My Task' }),
+			typeDefEntry('Person', { _icon: 'users' }),
+		];
+		const map = buildTypeMetadataMap(entries);
+		expect(map.size).toBe(2);
+		expect(map.get('Project')?.icon).toBe('rocket');
+		expect(map.get('Person')?.icon).toBe('users');
+	});
+
+	it('returns empty map when no type definitions', () => {
+		const entries = [
+			entryV2('/v/a.md', { isA: 'Project' }),
+			entryV2('/v/b.md'),
+		];
+		expect(buildTypeMetadataMap(entries).size).toBe(0);
+	});
+});
+
+describe('getTypeMetadataFallback', () => {
+	it('returns from map when present', () => {
+		const map = new Map([['Project', extractTypeMetadata(typeDefEntry('Project', { _icon: 'star' }))]]);
+		const meta = getTypeMetadataFallback('Project', map);
+		expect(meta.icon).toBe('star');
+	});
+
+	it('falls back to builtin for known types', () => {
+		const meta = getTypeMetadataFallback('Project', new Map());
+		expect(meta.icon).toBe('rocket');
+		expect(meta.color).toBe('red');
+	});
+
+	it('falls back to defaults for unknown types', () => {
+		const meta = getTypeMetadataFallback('Widget', new Map());
+		expect(meta.icon).toBe('file-text');
+		expect(meta.name).toBe('Widget');
+		expect(meta.sidebarLabel).toBe('Widgets');
+	});
+});

--- a/src/tests/lib/features/type-definitions/type-definitions.service.test.ts
+++ b/src/tests/lib/features/type-definitions/type-definitions.service.test.ts
@@ -76,7 +76,6 @@ describe('updateTypeDefinitionIcon', () => {
 			'---\ntype: Type\n---\n# Note\n'
 		);
 		await updateTypeDefinitionIcon('/vault/Note.md', null, null);
-		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
-		expect(written).toContain('type: Type');
+		expect(vi.mocked(writeTextFile)).not.toHaveBeenCalled();
 	});
 });

--- a/src/tests/lib/features/type-definitions/type-definitions.service.test.ts
+++ b/src/tests/lib/features/type-definitions/type-definitions.service.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+	readTextFile: vi.fn(),
+	writeTextFile: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+	invoke: vi.fn(),
+}));
+
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+import { updateTypeDefinitionIcon } from '$lib/features/type-definitions/type-definitions.service';
+
+describe('updateTypeDefinitionIcon', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(writeTextFile).mockResolvedValue(undefined);
+	});
+
+	it('adds _icon when not present in frontmatter', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n---\n# Project\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Project.md', 'rocket', null);
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('_icon: rocket');
+		expect(written).toContain('type: Type');
+		expect(written).toContain('# Project');
+	});
+
+	it('updates existing _icon value', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n_icon: file-text\n---\n# Project\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Project.md', 'rocket', null);
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('_icon: rocket');
+		expect(written).not.toContain('file-text');
+	});
+
+	it('adds _color when not present', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n---\n# Project\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Project.md', null, '#ef4444');
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('_color:');
+		expect(written).toContain('#ef4444');
+	});
+
+	it('updates both _icon and _color together', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n_icon: tag\n_color: green\n---\n# Topic\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Topic.md', 'users', 'blue');
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('_icon: users');
+		expect(written).toContain('_color: blue');
+		expect(written).not.toContain('tag');
+		expect(written).not.toContain('green');
+	});
+
+	it('preserves body content after frontmatter', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n---\n# Person\n\nSome description here.\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Person.md', 'users', null);
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('# Person');
+		expect(written).toContain('Some description here.');
+	});
+
+	it('does not write when both icon and color are null', async () => {
+		vi.mocked(readTextFile).mockResolvedValue(
+			'---\ntype: Type\n---\n# Note\n'
+		);
+		await updateTypeDefinitionIcon('/vault/Note.md', null, null);
+		const written = vi.mocked(writeTextFile).mock.calls[0][1] as string;
+		expect(written).toContain('type: Type');
+	});
+});

--- a/src/tests/lib/features/type-definitions/type-sidebar.logic.test.ts
+++ b/src/tests/lib/features/type-definitions/type-sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { buildTypeSections, countInbox } from '$lib/features/type-definitions/type-sidebar.logic';
 import { entryV2 } from '../../../fixtures/vault-entries.fixture';
 import type { TypeMetadata } from '$lib/features/type-definitions/type-definitions.logic';
+import type { NoteEntryV2 } from '$lib/types/vault-v2.types';
 
 function meta(name: string, overrides: Partial<TypeMetadata> = {}): TypeMetadata {
 	return {
@@ -115,6 +116,33 @@ describe('buildTypeSections', () => {
 			entryV2('/v/a.md', { title: 'A', isA: 'Hidden' }),
 		];
 		const map = new Map([['Hidden', meta('Hidden', { visible: false })]]);
+		const { sections } = buildTypeSections(entries, map, 'all');
+		expect(sections.length).toBe(0);
+	});
+
+	it('shows type definitions with no notes as empty sections', () => {
+		const entries = [
+			entryV2('/v/Sprint.md', { title: 'Sprint', isA: 'Type' }),
+			entryV2('/v/a.md', { title: 'A', isA: 'Project' }),
+		];
+		const map = new Map([
+			['Sprint', meta('Sprint', { order: 1, sidebarLabel: 'Sprints' })],
+			['Project', meta('Project', { order: 2 })],
+		]);
+		const { sections } = buildTypeSections(entries, map, 'all');
+		expect(sections.length).toBe(2);
+		expect(sections[0].metadata.name).toBe('Sprint');
+		expect(sections[0].notes.length).toBe(0);
+		expect(sections[0].definitionPath).toBe('/v/Sprint.md');
+		expect(sections[1].metadata.name).toBe('Project');
+		expect(sections[1].notes.length).toBe(1);
+	});
+
+	it('does not show empty sections for invisible type definitions', () => {
+		const entries: NoteEntryV2[] = [];
+		const map = new Map([
+			['Hidden', meta('Hidden', { visible: false })],
+		]);
 		const { sections } = buildTypeSections(entries, map, 'all');
 		expect(sections.length).toBe(0);
 	});

--- a/src/tests/lib/features/type-definitions/type-sidebar.logic.test.ts
+++ b/src/tests/lib/features/type-definitions/type-sidebar.logic.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { buildTypeSections, countInbox } from '$lib/features/type-definitions/type-sidebar.logic';
+import { entryV2 } from '../../../fixtures/vault-entries.fixture';
+import type { TypeMetadata } from '$lib/features/type-definitions/type-definitions.logic';
+
+function meta(name: string, overrides: Partial<TypeMetadata> = {}): TypeMetadata {
+	return {
+		name,
+		icon: 'file-text',
+		color: 'gray',
+		order: 50,
+		sidebarLabel: `${name}s`,
+		template: null,
+		sort: 'title',
+		view: 'all',
+		visible: true,
+		listPropertiesDisplay: [],
+		...overrides,
+	};
+}
+
+describe('buildTypeSections', () => {
+	it('groups entries by type', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Project' }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project' }),
+			entryV2('/v/c.md', { title: 'C', isA: 'Person' }),
+		];
+		const map = new Map([
+			['Project', meta('Project', { order: 1 })],
+			['Person', meta('Person', { order: 2 })],
+		]);
+		const { sections, untyped } = buildTypeSections(entries, map, 'all');
+		expect(sections.length).toBe(2);
+		expect(sections[0].metadata.name).toBe('Project');
+		expect(sections[0].notes.length).toBe(2);
+		expect(sections[1].metadata.name).toBe('Person');
+		expect(untyped.length).toBe(0);
+	});
+
+	it('puts notes without isA into untyped', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: null }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project' }),
+		];
+		const { sections, untyped } = buildTypeSections(entries, new Map(), 'all');
+		expect(sections.length).toBe(1);
+		expect(untyped.length).toBe(1);
+		expect(untyped[0].title).toBe('A');
+	});
+
+	it('excludes Type Definition entries from sections', () => {
+		const entries = [
+			entryV2('/v/Project.md', { title: 'Project', isA: 'Type' }),
+			entryV2('/v/a.md', { title: 'A', isA: 'Project' }),
+		];
+		const { sections } = buildTypeSections(entries, new Map(), 'all');
+		expect(sections[0].notes.length).toBe(1);
+	});
+
+	it('filters archived in all mode', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Project', archived: false }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project', archived: true }),
+		];
+		const { sections } = buildTypeSections(entries, new Map(), 'all');
+		expect(sections[0].notes.length).toBe(1);
+	});
+
+	it('inbox filter shows only non-organized non-archived', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Project', organized: false, archived: false }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project', organized: true, archived: false }),
+		];
+		const { sections } = buildTypeSections(entries, new Map(), 'inbox');
+		expect(sections[0].notes.length).toBe(1);
+		expect(sections[0].notes[0].title).toBe('A');
+	});
+
+	it('archived filter shows only archived', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Project', archived: true }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project', archived: false }),
+		];
+		const { sections } = buildTypeSections(entries, new Map(), 'archived');
+		expect(sections[0].notes.length).toBe(1);
+		expect(sections[0].notes[0].title).toBe('A');
+	});
+
+	it('favorites filter shows only favorites', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Project', favorite: true }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project', favorite: false }),
+		];
+		const { sections } = buildTypeSections(entries, new Map(), 'favorites');
+		expect(sections[0].notes.length).toBe(1);
+	});
+
+	it('sorts sections by order', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Person' }),
+			entryV2('/v/b.md', { title: 'B', isA: 'Project' }),
+		];
+		const map = new Map([
+			['Project', meta('Project', { order: 1 })],
+			['Person', meta('Person', { order: 2 })],
+		]);
+		const { sections } = buildTypeSections(entries, map, 'all');
+		expect(sections[0].metadata.name).toBe('Project');
+		expect(sections[1].metadata.name).toBe('Person');
+	});
+
+	it('hides sections with visible: false', () => {
+		const entries = [
+			entryV2('/v/a.md', { title: 'A', isA: 'Hidden' }),
+		];
+		const map = new Map([['Hidden', meta('Hidden', { visible: false })]]);
+		const { sections } = buildTypeSections(entries, map, 'all');
+		expect(sections.length).toBe(0);
+	});
+});
+
+describe('countInbox', () => {
+	it('counts non-organized non-archived non-Type entries', () => {
+		const entries = [
+			entryV2('/v/a.md', { organized: false, archived: false, isA: null }),
+			entryV2('/v/b.md', { organized: true, archived: false, isA: null }),
+			entryV2('/v/c.md', { organized: false, archived: true, isA: null }),
+			entryV2('/v/d.md', { organized: false, archived: false, isA: 'Type' }),
+		];
+		expect(countInbox(entries)).toBe(1);
+	});
+});

--- a/src/tests/lib/types/vault-v2.types.test.ts
+++ b/src/tests/lib/types/vault-v2.types.test.ts
@@ -83,6 +83,7 @@ describe('vault-v2.types', () => {
 				wordCount: 5,
 				snippet: 'Hello world',
 				tasks: [],
+				isA: null,
 			};
 
 			// Type-level checks lock the field names + types so a Rust-side

--- a/src/tests/lib/types/vault-v2.types.test.ts
+++ b/src/tests/lib/types/vault-v2.types.test.ts
@@ -108,11 +108,18 @@ describe('vault-v2.types', () => {
 			// Runtime sanity-check that the keys exist (no rogue snake_case).
 			const keys = Object.keys(entry).sort();
 			expect(keys).toEqual([
+				'archived',
+				'belongsTo',
 				'createdAt',
+				'favorite',
 				'frontmatter',
+				'isA',
 				'modifiedAt',
+				'organized',
 				'outgoingLinks',
 				'path',
+				'relatedTo',
+				'relationships',
 				'size',
 				'snippet',
 				'tags',

--- a/src/tests/lib/types/vault-v2.types.test.ts
+++ b/src/tests/lib/types/vault-v2.types.test.ts
@@ -87,6 +87,9 @@ describe('vault-v2.types', () => {
 				organized: false,
 				archived: false,
 				favorite: false,
+				belongsTo: [],
+				relatedTo: [],
+				relationships: {},
 			};
 
 			// Type-level checks lock the field names + types so a Rust-side

--- a/src/tests/lib/types/vault-v2.types.test.ts
+++ b/src/tests/lib/types/vault-v2.types.test.ts
@@ -84,6 +84,9 @@ describe('vault-v2.types', () => {
 				snippet: 'Hello world',
 				tasks: [],
 				isA: null,
+				organized: false,
+				archived: false,
+				favorite: false,
 			};
 
 			// Type-level checks lock the field names + types so a Rust-side

--- a/src/tests/lib/utils/frontmatter-aliases.test.ts
+++ b/src/tests/lib/utils/frontmatter-aliases.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeKey } from '$lib/utils/frontmatter-aliases';
+
+describe('canonicalizeKey', () => {
+	it('resolves type aliases', () => {
+		expect(canonicalizeKey('is_a')).toBe('type');
+		expect(canonicalizeKey('is a')).toBe('type');
+	});
+
+	it('resolves relationship aliases', () => {
+		expect(canonicalizeKey('belongs to')).toBe('belongs_to');
+		expect(canonicalizeKey('related to')).toBe('related_to');
+	});
+
+	it('resolves system underscore aliases', () => {
+		expect(canonicalizeKey('organized')).toBe('_organized');
+		expect(canonicalizeKey('archived')).toBe('_archived');
+		expect(canonicalizeKey('favorite')).toBe('_favorite');
+		expect(canonicalizeKey('order')).toBe('_order');
+		expect(canonicalizeKey('sort')).toBe('_sort');
+		expect(canonicalizeKey('icon')).toBe('_icon');
+		expect(canonicalizeKey('color')).toBe('_color');
+		expect(canonicalizeKey('template')).toBe('_template');
+		expect(canonicalizeKey('view')).toBe('_view');
+		expect(canonicalizeKey('visible')).toBe('_visible');
+		expect(canonicalizeKey('list_properties_display')).toBe('_list_properties_display');
+	});
+
+	it('resolves sidebar_label aliases', () => {
+		expect(canonicalizeKey('sidebar_label')).toBe('_sidebar_label');
+		expect(canonicalizeKey('sidebar label')).toBe('_sidebar_label');
+	});
+
+	it('passes through canonical keys unchanged', () => {
+		expect(canonicalizeKey('type')).toBe('type');
+		expect(canonicalizeKey('belongs_to')).toBe('belongs_to');
+		expect(canonicalizeKey('_organized')).toBe('_organized');
+		expect(canonicalizeKey('_icon')).toBe('_icon');
+	});
+
+	it('passes through unknown keys unchanged', () => {
+		expect(canonicalizeKey('title')).toBe('title');
+		expect(canonicalizeKey('tags')).toBe('tags');
+		expect(canonicalizeKey('custom_field')).toBe('custom_field');
+	});
+});


### PR DESCRIPTION
## Summary

Implements the [Portent](https://portent.md) knowledge base spec as a proof of concept. Adds note types, semantic relationships, lifecycle workflow, and a type-grouped sidebar to Kokobrain.

### Phase 1 - Foundation (type + lifecycle)
- System metadata alias resolution for frontmatter keys (`is_a` -> `type`, `belongs to` -> `belongs_to`, etc.)
- `is_a` type field parsed from frontmatter in Rust `VaultIndex` and mirrored in TypeScript `NoteEntryV2`
- Lifecycle flags (`organized`, `archived`, `favorite`) in Rust index with UI actions (Organize, Archive, Favorite)
- Archived notes filtered from Quick Switcher and default sidebar views

### Phase 2 - Relationships
- `belongs_to` / `related_to` / custom wikilink fields parsed from frontmatter in Rust index
- Relationship backlinks section in the Backlinks panel (right sidebar)
- Collection filter extensions for type, relationship, and lifecycle fields

### Phase 3 - Navigation
- Type definition entries (`type: Type`) with customizable metadata (icon, color, order, template, etc.)
- Type-grouped sidebar mode with filter tabs (All, Inbox, Archived, Favorites)
- Inbox workflow with `explicitOrganization` setting toggle in Settings > Types
- Sidebar mode toggle button in file explorer header

### Bug fixes (from audit)
- `resolves_to()` basename fallback for path-prefixed wikilink targets in relationship fields
- Missing `explicitOrganization` getter in settings store
- Silent error swallowing in vault-index-updated listener, TypeSidebar, and SidebarModeToggle
- Dead `sortField` branch and redundant ternary in type-definitions logic

### Documentation
- New user guide chapter: [Types & Relationships](help/documentation/25-types-and-relationships.md)
- Updated README features list, project structure, and docs index
- Relationship backlinks documented in sidebar panels guide

## Files changed

**Rust (src-tauri/)**
- `vault/aliases.rs` — new: alias resolution map
- `vault/entry.rs` — new fields: `is_a`, `organized`, `archived`, `favorite`, `relationships`
- `vault/index.rs` — relationship backlink lookups, basename fix in `resolves_to()`
- `commands/vault.rs` — `get_relationship_backlinks_v2` command, `project_note_record` extensions
- Tests: `vault_entry_test.rs`, `vault_index_test.rs`, `vault_parsing_test.rs`

**Frontend (src/)**
- `types/vault-v2.types.ts` — `NoteEntryV2` extended with Portent fields
- `utils/frontmatter-aliases.ts` — TS-side alias canonicalization
- `core/settings/` — `explicitOrganization` setting, Types section in settings dialog
- `features/type-definitions/` — new: type definition parser, store, sidebar, inbox workflow
- `features/properties/` — new: lifecycle logic, service, store, filter, UI actions
- `features/backlinks/` — relationship backlinks in panel and service
- `features/collection/` — Portent field resolvers for collection filters
- `features/quick-switcher/` — archived note filtering
- Tests for all new logic files

**Docs**
- `help/documentation/25-types-and-relationships.md` — new chapter
- `help/documentation/README.md`, `07-sidebar-panels.md`, `README.md` — updated

## Test plan

- [x] `cargo test` passes (Rust)
- [x] `pnpm check` passes (TypeScript)
- [x] `pnpm vitest run` passes (frontend tests)
- [ ] Manual: create a note with `type: Project`, verify it appears in type sidebar
- [ ] Manual: add `belongs_to: [[Other Note]]`, verify relationship backlink appears
- [ ] Manual: toggle Organize/Archive/Favorite in Properties panel
- [ ] Manual: enable Explicit Organization in Settings > Types, verify Inbox tab appears
- [ ] Manual: toggle sidebar mode between Files and Types via header button