### PR TITLE
fix(ci): make the aggregated PR gate (pr.yml) start and go green

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,12 +98,20 @@ jobs:
     name: Security
     needs: changes
     if: needs.changes.outputs.security == 'true'
-    # Job-level permissions REPLACE workflow-level, so redeclare the
-    # contents: read baseline alongside the checks: write that
-    # security.yml's cargo-audit job needs (mirrors run-all.yml).
+    # Job-level permissions REPLACE workflow-level, so this must grant the
+    # UNION of every permission the nested security.yml jobs request —
+    # GitHub validates a called workflow's permissions statically, at load
+    # time, BEFORE any job's `if` is evaluated. cargo-audit needs
+    # checks: write; osv-scanner requests actions: read + security-events:
+    # write. osv-scanner is gated off under workflow_call by its
+    # `github.workflow == 'Security'` guard and never actually runs here,
+    # but its request is still validated up front, so the grant is
+    # required regardless or the whole workflow fails to start.
     permissions:
       contents: read
       checks: write
+      actions: read
+      security-events: write
     uses: ./.github/workflows/security.yml
 
   # Aggregate gate — the single required status check for branch

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,6 +75,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: src-tauri
+          # Accepted advisories (see src-tauri/.cargo/audit.toml for the
+          # full rationale, which also covers local `cargo audit` runs —
+          # this action does NOT read that config file, so the list is
+          # mirrored here). RUSTSEC-2026-0194 / -0195: quick-xml 0.39.4 DoS,
+          # pulled ONLY by wayland-scanner (arboard's Linux Wayland
+          # clipboard backend, a build-time proc-macro over trusted
+          # protocol XML), pinned at ^0.39 upstream so unreachable from
+          # 0.41; not built on macOS. Drop when wayland-scanner bumps it.
+          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195
 
   supply-chain-quarantine:
     name: Supply Chain Quarantine

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,25 @@
+# cargo-audit configuration.
+#
+# Governs LOCAL `cargo audit` runs (the CLI reads .cargo/audit.toml). CI
+# does NOT use this file: rustsec/audit-check ignores it, so the same list
+# is mirrored in the `ignore:` input of the cargo-audit step in
+# .github/workflows/security.yml. Keep the two in sync.
+#
+# [advisories.ignore] — accepted advisories with rationale. Re-audit each
+# when the upstream chain that pulls the vulnerable crate ships a fix.
+[advisories]
+ignore = [
+    # quick-xml 0.39.4 DoS advisories (RUSTSEC-2026-0194 quadratic
+    # duplicate-attribute check, RUSTSEC-2026-0195 unbounded namespace
+    # allocation). The runtime consumer (plist, via tauri) was already
+    # moved to quick-xml 0.41.0. The residual 0.39.4 is pulled ONLY by
+    # wayland-scanner — arboard's Linux Wayland clipboard backend, a
+    # build-time proc-macro that parses the trusted, crate-shipped Wayland
+    # protocol XML, never untrusted input — and is pinned at ^0.39 by
+    # wayland-client -> wl-clipboard-rs -> arboard, so 0.41 is unreachable
+    # without an upstream release in that chain. Not compiled on macOS and
+    # not exploitable through build-time trusted input. Drop these when
+    # wayland-scanner bumps quick-xml.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]


### PR DESCRIPTION
## Context

PR #150 introduced `pr.yml` (the aggregated PR gate), but it hit a **`startup_failure` on every PR** — reproduced on an open, unmerged PR, so it was **not** a merge race. This PR fixes the gate and gets it green.

## What changes

**1. Permissions for the `security` job in `pr.yml`** (`fix(ci): grant pr.yml security job the union of nested permissions`)

GitHub validates a called workflow's permissions **statically, before any `if` runs**. `security.yml`'s `osv-scanner` job requests `actions: read` + `security-events: write`; even though it is gated off under `workflow_call` (`github.workflow == 'Security'`), the request is still checked at load time. The `security` caller job in `pr.yml` only granted `contents: read` + `checks: write` → invalid workflow, never started. It now grants the **union** of the nested jobs' permissions.

**2. Accepted quick-xml/Wayland advisories in cargo audit** (`fix(ci): mark accepted wayland quick-xml advisories in cargo audit`)

`RUSTSEC-2026-0194` / `-0195` (quick-xml 0.39.4 DoS) come **only** from `wayland-scanner` (arboard's Linux Wayland clipboard backend, a build-time proc-macro over trusted, crate-shipped protocol XML), pinned at `^0.39` upstream, so quick-xml 0.41 is unreachable without a release in the `wayland-client -> wl-clipboard-rs -> arboard` chain. Not built on macOS, and not exploitable through the build-time trusted input. Ignored with rationale: `ignore:` input on the `rustsec/audit-check` action (CI) + `src-tauri/.cargo/audit.toml` (local — the action does not read that file), kept in sync. Any new advisory still fails the job.

## Verification (this branch, full matrix)

Every `pr.yml` job green:

- Detect Changes ✅
- CI: Frontend (typecheck + tests + build) ✅, Rust (cargo test) ✅, Rust macOS fonts ✅, CI success ✅
- E2E (Playwright) ✅
- Security: npm Audit ✅, Cargo Audit ✅, Supply Chain Quarantine ✅, OSV Scanner ⏭️ skipped (correct under `workflow_call`)
- **PR success ✅**

Ready to merge. (The branch keeps the `chore/verify-pr-gate` name because it was reused instead of opening a new PR; the throwaway trigger commit was removed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
